### PR TITLE
Fix some saving issues

### DIFF
--- a/source/OptionsMenu.hx
+++ b/source/OptionsMenu.hx
@@ -121,6 +121,7 @@ class OptionsMenu extends MusicBeatState
 						FlxG.switchState(new LoadReplayState());
 				}
 			}
+		FlxG.save.flush();
 	}
 
 	var isSettingControl:Bool = false;

--- a/source/TitleState.hx
+++ b/source/TitleState.hx
@@ -66,6 +66,8 @@ class TitleState extends MusicBeatState
 		trace('NEWGROUNDS LOL');
 		#end
 
+		FlxG.save.bind('funkin', 'ninjamuffin99');
+
 		if (FlxG.save.data.newInput == null)
 			FlxG.save.data.newInput = true;
 
@@ -77,8 +79,12 @@ class TitleState extends MusicBeatState
 		
 		if (FlxG.save.data.accuracyDisplay == null)
 			FlxG.save.data.accuracyDisplay = true;
-			
-		FlxG.save.bind('funkin', 'ninjamuffin99');
+
+		if (FlxG.save.data.accuracyDisplay == null)
+			FlxG.save.data.accuracyDisplay = true;
+
+		if (FlxG.save.data.offset == null)
+			FlxG.save.data.offset = 0;
 
 		Highscore.load();
 


### PR DESCRIPTION
This fixes some saving issues.
The first makes the web build unplayable, since the save data from the Kade Engine isn't created properly in TitleState and it's missing the offset variable which is used in PlayState. It is fixed by moving the save bind before the declaration of the new save data variables, and adds the missing offset variable
The second one doesn't let the web build save the changes made in the options menu, this is due to a missing flush. It is simply fixed by adding a flush at the end of the function.