### PR TITLE
Update rank scoring for it to always show FC when there are no misses and show SS when 100% accuracy

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1340,7 +1340,7 @@ class PlayState extends MusicBeatState
 
 		if (FlxG.save.data.accuracyDisplay)
 		{
-			scoreTxt.text = "Score:" + songScore + " | Misses:" + misses + " | Accuracy:" + truncateFloat(accuracy, 2) + "% " + (fc ? "| FC" : misses == 0 ? "| A" : accuracy <= 75 ? "| BAD" : "");
+			scoreTxt.text = "Score:" + songScore + " | Misses:" + misses + " | Accuracy:" + truncateFloat(accuracy, 2) + "% " + (accuracy == 100 ? "| SS" : fc ? "| FC" : accuracy <= 75 ? "| BAD" : "");
 		}
 		else
 		{
@@ -2347,7 +2347,7 @@ class PlayState extends MusicBeatState
 
 	function updateAccuracy()
 		{
-			if (misses > 0 || accuracy < 96)
+			if (misses > 0)
 				fc = false;
 			else
 				fc = true;


### PR DESCRIPTION
IMO it should say something like PERFECT or SS when it's perfect and it should always show FC when there are no misses as it it is still a full combo