### PR TITLE
(Help Wanted) Fixed Note Speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 export/
 .vscode/
+.gitignore
 APIStuff.hx

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 export/
 .vscode/
-.gitignore
 APIStuff.hx

--- a/source/OptionsMenu.hx
+++ b/source/OptionsMenu.hx
@@ -17,6 +17,8 @@ class OptionsMenu extends MusicBeatState
 {
 	var selector:FlxText;
 	var curSelected:Int = 0;
+	var chartSpeed:FlxText;
+	var speedState:String;
 
 	var controlsStrings:Array<String> = [];
 
@@ -31,6 +33,7 @@ class OptionsMenu extends MusicBeatState
 			"\n" + (FlxG.save.data.downscroll ? 'Downscroll' : 'Upscroll') + 
 			"\nAccuracy " + (!FlxG.save.data.accuracyDisplay ? "off" : "on") + 
 			"\nSong Position " + (!FlxG.save.data.songPosition ? "off" : "on") +
+			"\nNote Speed" +
 			"\nEtterna Mode " + (!FlxG.save.data.etternaMode ? "off" : "on") +
 			"\nLoad replays");
 		
@@ -61,6 +64,20 @@ class OptionsMenu extends MusicBeatState
 		versionShit.setFormat("VCR OSD Mono", 16, FlxColor.WHITE, LEFT, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
 		add(versionShit);
 
+		var tmp_Speed:Float = FlxG.save.data.noteSpeed;
+
+		chartSpeed = new FlxText(FlxG.width - 387, FlxG.height - 18, 0, "Note Speed (Hover, then Left and Right): " + tmp_Speed, 12);
+		chartSpeed.scrollFactor.set();
+		chartSpeed.setFormat("VCR OSD Mono", 16, FlxColor.WHITE, LEFT, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
+
+		if(tmp_Speed == -1) chartSpeed.x = FlxG.width - 470;
+		else if(tmp_Speed == 1.5 || tmp_Speed == 2.5 || tmp_Speed == 3.5) chartSpeed.x = FlxG.width - 405;
+		else chartSpeed.x = FlxG.width - 387;
+
+		if(FlxG.save.data.noteSpeed > 0) chartSpeed.text = "Note Speed (Hover, then Left and Right): " + FlxG.save.data.noteSpeed.toString();
+		else chartSpeed.text = "Note Speed (Hover, then Left and Right): Song Based";
+		add(chartSpeed);
+		
 		super.create();
 	}
 
@@ -77,21 +94,72 @@ class OptionsMenu extends MusicBeatState
 			
 			if (controls.RIGHT_R)
 			{
-				FlxG.save.data.offset++;
-				versionShit.text = "Offset (Left, Right): " + FlxG.save.data.offset;
+				if(curSelected != 5)
+				{
+					FlxG.save.data.offset++;
+					versionShit.text = "Offset (Left, Right): " + FlxG.save.data.offset;
+				}else {
+					if(FlxG.save.data.noteSpeed < 4.0) 
+						if(FlxG.save.data.noteSpeed == -1) FlxG.save.data.noteSpeed = 1.0;
+						else FlxG.save.data.noteSpeed += 0.5;
+					
+					grpControls.remove(grpControls.members[curSelected]);
+					var ctrl:Alphabet = new Alphabet(0, (70 * curSelected) + 30, "Note Speed", true, false);
+					ctrl.isMenuItem = true;
+					ctrl.targetY = curSelected - 5;
+					grpControls.add(ctrl);
+					
+					if(FlxG.save.data.noteSpeed > 0) speedState = FlxG.save.data.noteSpeed.toString();
+					else speedState = "Song Based";
+					
+					chartSpeed.text = "Note Speed (Hover, then Left and Right): " + speedState;
+					
+					trace(FlxG.save.data.noteSpeed);
+				}
 			}
 
 			if (controls.LEFT_R)
+			{
+				if(curSelected != 5)
 				{
 					FlxG.save.data.offset--;
 					versionShit.text = "Offset (Left, Right): " + FlxG.save.data.offset;
+				}else {
+					if(FlxG.save.data.noteSpeed > 1.0) FlxG.save.data.noteSpeed -= 0.5;
+					else FlxG.save.data.noteSpeed = -1;
+					
+					trace(FlxG.save.data.noteSpeed);
+					var speedState = "";
+					
+					if(FlxG.save.data.noteSpeed > 0) speedState = FlxG.save.data.noteSpeed.toString();
+					else speedState = "Song Based";
+					
+					chartSpeed.text = "Note Speed (Hover, then Left and Right): " + speedState;
+					
+					grpControls.remove(grpControls.members[curSelected]);
+					var ctrl:Alphabet = new Alphabet(0, (70 * curSelected) + 30, "Note Speed", true, false);
+					ctrl.isMenuItem = true;
+					ctrl.targetY = curSelected - 5;
+					grpControls.add(ctrl);
+					
+					trace(FlxG.save.data.noteSpeed);
 				}
+			}
 	
+			if(controls.LEFT_R  && curSelected == 5 || controls.RIGHT_R && curSelected == 5 )
+			{
+				var tmp_Speed:Float = FlxG.save.data.noteSpeed;
+				
+				if(tmp_Speed == -1) chartSpeed.x = FlxG.width - 470;
+				else if(tmp_Speed == 1.5 || tmp_Speed == 2.5 || tmp_Speed == 3.5) chartSpeed.x = FlxG.width - 405;
+				else chartSpeed.x = FlxG.width - 387;
+			}
 
 			if (controls.ACCEPT)
 			{
-				if (curSelected != 6)
+				if (curSelected != 7 && curSelected != 5)
 					grpControls.remove(grpControls.members[curSelected]);
+				
 				switch(curSelected)
 				{
 					case 0:
@@ -129,13 +197,13 @@ class OptionsMenu extends MusicBeatState
 						ctrl.isMenuItem = true;
 						ctrl.targetY = curSelected - 4;
 						grpControls.add(ctrl);
-					case 5:
+					case 6:
 						FlxG.save.data.etternaMode = !FlxG.save.data.etternaMode;
 						var ctrl:Alphabet = new Alphabet(0, (70 * curSelected) + 30, "Etterna Mode " + (!FlxG.save.data.etternaMode ? "off" : "on"), true, false);
 						ctrl.isMenuItem = true;
-						ctrl.targetY = curSelected - 5;
+						ctrl.targetY = curSelected - 6;
 						grpControls.add(ctrl);
-					case 6:
+					case 7:
 						trace('switch');
 						FlxG.switchState(new LoadReplayState());
 				}

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1881,9 +1881,14 @@ class PlayState extends MusicBeatState
 					}
 	
 					if (FlxG.save.data.downscroll)
-						daNote.y = (strumLine.y - (Conductor.songPosition - daNote.strumTime) * (-0.45 * FlxMath.roundDecimal(SONG.speed, 2)));
+						if(FlxG.save.data.noteSpeed != -1)
+							daNote.y = (strumLine.y - (Conductor.songPosition - daNote.strumTime) * (-0.45 * FlxMath.roundDecimal(FlxG.save.data.noteSpeed, 2)));
+						else daNote.y = (strumLine.y - (Conductor.songPosition - daNote.strumTime) * (-0.45 * FlxMath.roundDecimal(SONG.speed, 2)));
 					else
-						daNote.y = (strumLine.y - (Conductor.songPosition - daNote.strumTime) * (0.45 * FlxMath.roundDecimal(SONG.speed, 2)));
+						if(FlxG.save.data.noteSpeed != -1)
+							daNote.y = (strumLine.y - (Conductor.songPosition - daNote.strumTime) * (0.45 * FlxMath.roundDecimal(FlxG.save.data.noteSpeed, 2)));
+						else daNote.y = (strumLine.y - (Conductor.songPosition - daNote.strumTime) * (0.45 * FlxMath.roundDecimal(SONG.speed, 2)));
+					
 					//trace(daNote.y);
 					// WIP interpolation shit? Need to fix the pause issue
 					// daNote.y = (strumLine.y - (songTime - daNote.strumTime) * (0.45 * PlayState.SONG.speed));


### PR DESCRIPTION
Implements a bugged fixed note speed to the game along with a space on the Options menu and everything. #53, #52.

![Screenshot_26](https://user-images.githubusercontent.com/44783518/112274575-689e8b00-8c5d-11eb-8c8c-2bc9d01616c2.png)

**KNOWN ISSUES**
_— Upscroll hold trails start to offset away from the arrow sprite the more you increase note speed.
— Downscroll hold trails work fine but the end piece offsets instead.
— Week 6 curb stomps this system by completely messing up the sprites y axis scaling._

Honestly, I've been working on this for days now and couldn't fix it for the life of me. Still, I thought it'd be cool to show my progress with it.