### PR TITLE
Fix replay crashes on non-Windows platforms

### DIFF
--- a/source/LoadReplayState.hx
+++ b/source/LoadReplayState.hx
@@ -33,7 +33,7 @@ class LoadReplayState extends MusicBeatState
 	{
 		var menuBG:FlxSprite = new FlxSprite().loadGraphic(Paths.image('menuDesat'));
         #if sys
-		controlsStrings = sys.FileSystem.readDirectory(Sys.getCwd() + "\\assets\\replays\\");
+		controlsStrings = sys.FileSystem.readDirectory(Sys.getCwd() + "/assets/replays/");
         #end
 		trace(controlsStrings);
 

--- a/source/Replay.hx
+++ b/source/Replay.hx
@@ -85,10 +85,10 @@ class Replay
     public function LoadFromJSON()
     {
         #if sys
-        trace('loading ' + Sys.getCwd() + 'assets\\replays\\' + path + ' replay...');
+        trace('loading ' + Sys.getCwd() + 'assets/replays/' + path + ' replay...');
         try
         {
-            var repl:ReplayJSON = cast Json.parse(File.getContent(Sys.getCwd() + "assets\\replays\\" + path));
+            var repl:ReplayJSON = cast Json.parse(File.getContent(Sys.getCwd() + "assets/replays/" + path));
             replay = repl;
         }
         catch(e)

--- a/source/TitleState.hx
+++ b/source/TitleState.hx
@@ -52,8 +52,8 @@ class TitleState extends MusicBeatState
 		#end
 		
 		#if sys
-		if (!sys.FileSystem.exists(Sys.getCwd() + "\\assets\\replays"))
-			sys.FileSystem.createDirectory(Sys.getCwd() + "\\assets\\replays");
+		if (!sys.FileSystem.exists(Sys.getCwd() + "/assets/replays"))
+			sys.FileSystem.createDirectory(Sys.getCwd() + "/assets/replays");
 		#end
 
 		


### PR DESCRIPTION
Replays attempt to save to `\assets\replays`, resulting in crashes on systems that don't use backslashes for folder paths (e.g. macOS, Linux).
IIRC Windows just treats backslashes and forward slashes the same.

Should fix #18. It works on Linux but I don't have a macOS machine to test.