### PR TITLE
Player 2 now plays idle animation properly when camera zooms in

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -3881,7 +3881,15 @@ class PlayState extends MusicBeatState
 			// Conductor.changeBPM(SONG.bpm);
 
 			// Dad doesnt interupt his own notes
-			if (SONG.notes[Math.floor(curStep / 16)].mustHitSection)
+			
+			// Commented out until a reason to bring this back arises in the future
+			/* if (SONG.notes[Math.floor(curStep / 16)].mustHitSection)
+				dad.dance(); */
+			
+			if(dad.animation.curAnim.name.startsWith('sing'))
+				if(dad.animation.finished)
+					dad.dance();
+			else
 				dad.dance();
 		}
 		// FlxG.log.add('change bpm' + SONG.notes[Std.int(curStep / 16)].changeBPM);


### PR DESCRIPTION
I know, strange but, in the words of **BrightFyre#0269**

![Screenshot_5](https://user-images.githubusercontent.com/44783518/115939631-15df0b80-a475-11eb-9a76-58a3e663feb5.png)
