### PR TITLE
Start_Linux.sh created.

### DIFF
--- a/start_linux.sh
+++ b/start_linux.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# check for wine
+# bash script made in 10s - dwifte
+# ill probably make a ui for this to make it easier :smile:
+if [ -f "/usr/bin/wine64" ]; then
+   echo "Wine Found."
+else
+   echo "Wine not found.\nPlease install it using your package manager."
+   exit 404
+fi
+
+# uses wine to launch Kade Engine.exe
+WINEPREFIX=~/.KadeEngine wine "Kade Engine.exe"


### PR DESCRIPTION
Allows Kade Engine.exe to be launched as no compiled builds are made for linux.

Noobie friendly i guess :)

Usage:

bash start_linux.sh

REQUIRES WINE :)

If you want. I can create a launcher which will:
Update to the latest Kade Engine version
Allows one click launch
shows stats? idk