### PR TITLE
check if initalized first before allowing user to skip intro

### DIFF
--- a/source/TitleState.hx
+++ b/source/TitleState.hx
@@ -335,7 +335,7 @@ class TitleState extends MusicBeatState
 			// FlxG.sound.play(Paths.music('titleShoot'), 0.7);
 		}
 
-		if (pressedEnter && !skippedIntro)
+		if (pressedEnter && !skippedIntro && initialized)
 		{
 			skipIntro();
 		}


### PR DESCRIPTION
prevents the game from crashing if the user spams enter right after launching the game up