### PR TITLE
improve flashing lights option

### DIFF
--- a/source/MainMenuState.hx
+++ b/source/MainMenuState.hx
@@ -11,6 +11,7 @@ import flixel.text.FlxText;
 import flixel.tweens.FlxEase;
 import flixel.tweens.FlxTween;
 import flixel.util.FlxColor;
+import flixel.util.FlxTimer;
 import io.newgrounds.NG;
 import lime.app.Application;
 
@@ -164,9 +165,8 @@ class MainMenuState extends MusicBeatState
 					selectedSomethin = true;
 					FlxG.sound.play(Paths.sound('confirmMenu'));
 					
-					if(FlxG.save.data.flashing){
+					if (FlxG.save.data.flashing)
 						FlxFlicker.flicker(magenta, 1.1, 0.15, false);
-					}
 
 					menuItems.forEach(function(spr:FlxSprite)
 					{
@@ -182,24 +182,20 @@ class MainMenuState extends MusicBeatState
 						}
 						else
 						{
-							FlxFlicker.flicker(spr, 1, 0.06, false, false, function(flick:FlxFlicker)
+							if (FlxG.save.data.flashing)
 							{
-								var daChoice:String = optionShit[curSelected];
-
-								switch (daChoice)
+								FlxFlicker.flicker(spr, 1, 0.06, false, false, function(flick:FlxFlicker)
 								{
-									case 'story mode':
-										FlxG.switchState(new StoryMenuState());
-										trace("Story Menu Selected");
-									case 'freeplay':
-										FlxG.switchState(new FreeplayState());
-
-										trace("Freeplay Menu Selected");
-
-									case 'options':
-										FlxG.switchState(new OptionsMenu());
-								}
-							});
+									goToState();
+								});
+							}
+							else
+							{
+								new FlxTimer().start(1, function(tmr:FlxTimer)
+								{
+									goToState();
+								});
+							}
 						}
 					});
 				}
@@ -212,6 +208,25 @@ class MainMenuState extends MusicBeatState
 		{
 			spr.screenCenter(X);
 		});
+	}
+	
+	function goToState()
+	{
+		var daChoice:String = optionShit[curSelected];
+
+		switch (daChoice)
+		{
+			case 'story mode':
+				FlxG.switchState(new StoryMenuState());
+				trace("Story Menu Selected");
+			case 'freeplay':
+				FlxG.switchState(new FreeplayState());
+
+				trace("Freeplay Menu Selected");
+
+			case 'options':
+				FlxG.switchState(new OptionsMenu());
+		}
 	}
 
 	function changeItem(huh:Int = 0)

--- a/source/MenuItem.hx
+++ b/source/MenuItem.hx
@@ -37,14 +37,13 @@ class MenuItem extends FlxSpriteGroup
 	{
 		super.update(elapsed);
 		y = FlxMath.lerp(y, (targetY * 120) + 480, 0.17 * (60 / FlxG.save.data.fpsCap));
-		if(FlxG.save.data.flashing){
-			if (isFlashing)
-				flashingInt += 1;
+
+		if (isFlashing)
+			flashingInt += 1;
 	
-			if (flashingInt % fakeFramerate >= Math.floor(fakeFramerate / 2))
-				week.color = 0xFF33ffff;
-			else
-				week.color = FlxColor.WHITE;
-		}
+		if (flashingInt % fakeFramerate >= Math.floor(fakeFramerate / 2))
+			week.color = 0xFF33ffff;
+		else if (FlxG.save.data.flashing)
+			week.color = FlxColor.WHITE;
 	}
 }

--- a/source/TitleState.hx
+++ b/source/TitleState.hx
@@ -295,7 +295,8 @@ class TitleState extends MusicBeatState
 				NGio.unlockMedal(61034);
 			#end
 
-			titleText.animation.play('press');
+			if (FlxG.save.data.flashing)
+				titleText.animation.play('press');
 
 			FlxG.camera.flash(FlxColor.WHITE, 1);
 			FlxG.sound.play(Paths.sound('confirmMenu'), 0.7);


### PR DESCRIPTION
prevents flashing press animation from playing on title, prevents selected main menu option from flashing, and sets selected story menu option to pure cyan when selected

https://user-images.githubusercontent.com/15317421/117620240-25bd4780-b125-11eb-8207-f5cb3a1e4810.mp4