### PR TITLE
Fix nps counter and add a max nps counter

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1649,6 +1649,8 @@ class PlayState extends MusicBeatState
 	private var paused:Bool = false;
 	var startedCountdown:Bool = false;
 	var canPause:Bool = true;
+	var nps:Int = 0;
+	var maxNPS:Int = 0;
 
 	public static var songRate = 1.5;
 
@@ -1732,6 +1734,8 @@ class PlayState extends MusicBeatState
 				balls--;
 			}
 			nps = notesHitArray.length;
+			if (nps > maxNPS)
+				maxNPS = nps;
 		}
 
 		if (FlxG.keys.justPressed.NINE)
@@ -1760,7 +1764,7 @@ class PlayState extends MusicBeatState
 
 		super.update(elapsed);
 
-		scoreTxt.text = Ratings.CalculateRanking(songScore,songScoreDef,nps,accuracy);
+		scoreTxt.text = Ratings.CalculateRanking(songScore,songScoreDef,nps,maxNPS,accuracy);
 		if (FlxG.keys.justPressed.ENTER && startedCountdown && canPause)
 		{
 			persistentUpdate = false;
@@ -3035,8 +3039,6 @@ class PlayState extends MusicBeatState
 
 				}
 		}
-
-		var nps:Int = 0;
 
 		function goodNoteHit(note:Note, resetMashViolation = true):Void
 			{

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1717,20 +1717,22 @@ class PlayState extends MusicBeatState
 
 		#end
 
-		if (currentFrames == FlxG.save.data.fpsCap)
+		// reverse iterate to remove oldest notes first and not invalidate the iteration
+		// stop iteration as soon as a note is not removed
+		// all notes should be kept in the correct order and this is optimal, safe to do every frame/update
 		{
-			for(i in 0...notesHitArray.length)
+			var balls = notesHitArray.length-1;
+			while (balls >= 0)
 			{
-				var cock:Date = notesHitArray[i];
-				if (cock != null)
-					if (cock.getTime() + 2000 < Date.now().getTime())
-						notesHitArray.remove(cock);
+				var cock:Date = notesHitArray[balls];
+				if (cock != null && cock.getTime() + 1000 < Date.now().getTime())
+					notesHitArray.remove(cock);
+				else
+					balls = 0;
+				balls--;
 			}
-			nps = Math.floor(notesHitArray.length / 2);
-			currentFrames = 0;
+			nps = notesHitArray.length;
 		}
-		else
-			currentFrames++;
 
 		if (FlxG.keys.justPressed.NINE)
 		{
@@ -3046,8 +3048,10 @@ class PlayState extends MusicBeatState
 
 				note.rating = Ratings.CalculateRating(noteDiff);
 
+				// add newest note to front of notesHitArray
+				// the oldest notes are at the end and are removed first
 				if (!note.isSustainNote)
-					notesHitArray.push(Date.now());
+					notesHitArray.unshift(Date.now());
 
 				if (!resetMashViolation && mashViolations >= 1)
 					mashViolations--;

--- a/source/Ratings.hx
+++ b/source/Ratings.hx
@@ -129,10 +129,10 @@ class Ratings
         return "sick";
     }
 
-    public static function CalculateRanking(score:Int,scoreDef:Int,nps:Int,accuracy:Float):String
+    public static function CalculateRanking(score:Int,scoreDef:Int,nps:Int,maxNPS:Int,accuracy:Float):String
     {
         return 
-        (FlxG.save.data.npsDisplay ? "NPS: " + nps + (!FlxG.save.data.botplay ? " | " : "") : "") + (!FlxG.save.data.botplay ?	// NPS Toggle
+        (FlxG.save.data.npsDisplay ? "NPS: " + nps + " (Max " + maxNPS + ")" + (!FlxG.save.data.botplay ? " | " : "") : "") + (!FlxG.save.data.botplay ?	// NPS Toggle
         "Score:" + (Conductor.safeFrames != 10 ? score + " (" + scoreDef + ")" : "" + score) + 									// Score
         " | Combo Breaks:" + PlayState.misses + 																				// Misses/Combo Breaks
         " | Accuracy:" + (FlxG.save.data.botplay ? "N/A" : HelperFunctions.truncateFloat(accuracy, 2) + " %") +  				// Accuracy


### PR DESCRIPTION
someone complained about the code that was written via telephone from me so i fixed it myself and felt generous so heres some max nps action to go with it

theres a more underlying issue which is that nps is calculated based on your own presses that are judged (and it does ignore the ones that are not judged) when instead it could be judged based off of the raw notes coming into the receptors

but i guess depending on your opinion this is more correct. whatever, thats not what this change is for