### PR TITLE
Replay now uses Botplay to simulate previous sessions

### DIFF
--- a/source/PauseSubState.hx
+++ b/source/PauseSubState.hx
@@ -182,6 +182,12 @@ class PauseSubState extends MusicBeatSubstate
 				case "Restart Song":
 					FlxG.resetState();
 				case "Exit to menu":
+					if(PlayState.loadRep)
+					{
+						FlxG.save.data.botplay = false;
+						FlxG.save.data.scrollSpeed = 1;
+						FlxG.save.data.downscroll = false;
+					}
 					PlayState.loadRep = false;
 					#if windows
 					if (PlayState.luaModchart != null)
@@ -192,6 +198,7 @@ class PauseSubState extends MusicBeatSubstate
 					#end
 					if (FlxG.save.data.fpsCap > 290)
 						(cast (Lib.current.getChildAt(0), Main)).setFPSCap(290);
+					
 					FlxG.switchState(new MainMenuState());
 			}
 		}

--- a/source/Replay.hx
+++ b/source/Replay.hx
@@ -11,26 +11,15 @@ import haxe.Json;
 import flixel.input.keyboard.FlxKey;
 import openfl.utils.Dictionary;
 
-typedef KeyPress =
-{
-    public var time:Float;
-    public var key:String;
-}
-
-typedef KeyRelease =
-{
-    public var time:Float;
-    public var key:String;
-}
-
 typedef ReplayJSON =
 {
     public var replayGameVer:String;
     public var timestamp:Date;
     public var songName:String;
     public var songDiff:Int;
-    public var keyPresses:Array<KeyPress>;
-    public var keyReleases:Array<KeyRelease>;
+    public var songNotes:Array<Float>;
+	public var noteSpeed:Float;
+	public var isDownscroll:Bool;
 }
 
 class Replay
@@ -44,9 +33,10 @@ class Replay
         this.path = path;
         replay = {
             songName: "Tutorial", 
-            songDiff: 1, 
-            keyPresses: [],
-            keyReleases: [],
+            songDiff: 1,
+			noteSpeed: 1.5,
+			isDownscroll: false,
+			songNotes: [],
             replayGameVer: version,
             timestamp: Date.now()
         };
@@ -58,18 +48,19 @@ class Replay
 
         rep.LoadFromJSON();
 
-        trace('basic replay data:\nSong Name: ' + rep.replay.songName + '\nSong Diff: ' + rep.replay.songDiff + '\nKeys Length: ' + rep.replay.keyPresses.length);
+        trace('basic replay data:\nSong Name: ' + rep.replay.songName + '\nSong Diff: ' + rep.replay.songDiff + '\nNotes Length: ' + rep.replay.songNotes.length);
 
         return rep;
     }
 
-    public function SaveReplay()
+    public function SaveReplay(notearray:Array<Float>)
     {
         var json = {
             "songName": PlayState.SONG.song.toLowerCase(),
             "songDiff": PlayState.storyDifficulty,
-            "keyPresses": replay.keyPresses,
-            "keyReleases": replay.keyReleases,
+			"noteSpeed": (FlxG.save.data.scrollSpeed > 1 ? FlxG.save.data.scrollSpeed : PlayState.SONG.speed),
+			"isDownscroll": FlxG.save.data.downscroll,
+			"songNotes": notearray,
             "timestamp": Date.now(),
             "replayGameVer": version
         };
@@ -80,7 +71,6 @@ class Replay
         File.saveContent("assets/replays/replay-" + PlayState.SONG.song + "-time" + Date.now().getTime() + ".kadeReplay", data);
         #end
     }
-
 
     public function LoadFromJSON()
     {


### PR DESCRIPTION
_Did a video about it that would explain quite a lot but, 200mb is too much for Github so here we go._

Replays will now save notes hit in the .kadeReplay file to reuse them while the replay is playing to tell which notes to hit and which notes to let go. The notes that are let go will be counted as a miss automatically (calling noteMiss is overkill, trust me).

It will also now save scroll speed and note direction (/\scroll or \/scroll). That's about it.
Also, gotta make sure to warn people that this isn't retroactive, so old .kadeReplay files won't work with this new version.

There are problems though, for some reason, some replays might fail to play properly because the amount of health lost might vary due to the logic used in BotPlay, but I didn't see that happening enough to become a real problem.

Other than that, it's working now.