### PR TITLE
magenta menu bg scroll factor fix

### DIFF
--- a/source/MainMenuState.hx
+++ b/source/MainMenuState.hx
@@ -73,7 +73,7 @@ class MainMenuState extends MusicBeatState
 
 		magenta = new FlxSprite(-80).loadGraphic(Paths.image('menuDesat'));
 		magenta.scrollFactor.x = 0;
-		magenta.scrollFactor.y = 0.18;
+		magenta.scrollFactor.y = 0.15;
 		magenta.setGraphicSize(Std.int(magenta.width * 1.1));
 		magenta.updateHitbox();
 		magenta.screenCenter();


### PR DESCRIPTION
idk why this was changed in the first place but the scrollfactor is now the same as the yellow bg so it doesn't jitter up and down a little bit when menu flashes