### PR TITLE
Added QWOP and Spread (ZX12) control schemes

### DIFF
--- a/source/Controls.hx
+++ b/source/Controls.hx
@@ -84,6 +84,8 @@ enum KeyboardScheme
 {
 	Solo;
 	Duo(first:Bool);
+	Qwop;
+	Spread;
 	None;
 	Custom;
 }
@@ -502,6 +504,24 @@ class Controls extends FlxActionSet
 				inline bindKeys(Control.DOWN, [F, FlxKey.DOWN]);
 				inline bindKeys(Control.LEFT, [D, FlxKey.LEFT]);
 				inline bindKeys(Control.RIGHT, [K, FlxKey.RIGHT]);
+				inline bindKeys(Control.ACCEPT, [Z, SPACE, ENTER]);
+				inline bindKeys(Control.BACK, [BACKSPACE, ESCAPE]);
+				inline bindKeys(Control.PAUSE, [P, ENTER, ESCAPE]);
+				inline bindKeys(Control.RESET, [R]);
+			case Qwop:
+				inline bindKeys(Control.UP, [O, FlxKey.UP]);
+				inline bindKeys(Control.DOWN, [W, FlxKey.DOWN]);
+				inline bindKeys(Control.LEFT, [Q, FlxKey.LEFT]);
+				inline bindKeys(Control.RIGHT, [P, FlxKey.RIGHT]);
+				inline bindKeys(Control.ACCEPT, [Z, SPACE, ENTER]);
+				inline bindKeys(Control.BACK, [BACKSPACE, ESCAPE]);
+				inline bindKeys(Control.PAUSE, [P, ENTER, ESCAPE]);
+				inline bindKeys(Control.RESET, [R]);
+			case Spread:
+				inline bindKeys(Control.UP, [FlxKey.NUMPADONE, FlxKey.UP]);
+				inline bindKeys(Control.DOWN, [X, FlxKey.DOWN]);
+				inline bindKeys(Control.LEFT, [Z, FlxKey.LEFT]);
+				inline bindKeys(Control.RIGHT, [FlxKey.NUMPADTWO, FlxKey.RIGHT]);
 				inline bindKeys(Control.ACCEPT, [Z, SPACE, ENTER]);
 				inline bindKeys(Control.BACK, [BACKSPACE, ESCAPE]);
 				inline bindKeys(Control.PAUSE, [P, ENTER, ESCAPE]);

--- a/source/KadeEngineData.hx
+++ b/source/KadeEngineData.hx
@@ -1,19 +1,19 @@
-import openfl.Lib;
 import flixel.FlxG;
+import openfl.Lib;
 
 class KadeEngineData
 {
-    public static function initSave()
-    {
-        if (FlxG.save.data.newInput == null)
+	public static function initSave()
+	{
+		if (FlxG.save.data.newInput == null)
 			FlxG.save.data.newInput = true;
 
 		if (FlxG.save.data.downscroll == null)
 			FlxG.save.data.downscroll = false;
 
 		if (FlxG.save.data.dfjk == null)
-			FlxG.save.data.dfjk = false;
-			
+			FlxG.save.data.dfjk = 0;
+
 		if (FlxG.save.data.accuracyDisplay == null)
 			FlxG.save.data.accuracyDisplay = true;
 
@@ -41,7 +41,7 @@ class KadeEngineData
 
 		if (FlxG.save.data.fpsCap > 285 || FlxG.save.data.fpsCap < 60)
 			FlxG.save.data.fpsCap = 120; // baby proof so you can't hard lock ur copy of kade engine
-		
+
 		if (FlxG.save.data.scrollSpeed == null)
 			FlxG.save.data.scrollSpeed = 1;
 
@@ -68,7 +68,7 @@ class KadeEngineData
 
 		if (FlxG.save.data.resetButton == null)
 			FlxG.save.data.resetButton = false;
-		
+
 		if (FlxG.save.data.botplay == null)
 			FlxG.save.data.botplay = false;
 
@@ -76,6 +76,6 @@ class KadeEngineData
 
 		Main.watermarks = FlxG.save.data.watermark;
 
-		(cast (Lib.current.getChildAt(0), Main)).setFPSCap(FlxG.save.data.fpsCap);
+		(cast(Lib.current.getChildAt(0), Main)).setFPSCap(FlxG.save.data.fpsCap);
 	}
 }

--- a/source/KadeEngineData.hx
+++ b/source/KadeEngineData.hx
@@ -1,11 +1,11 @@
-import flixel.FlxG;
 import openfl.Lib;
+import flixel.FlxG;
 
 class KadeEngineData
 {
-	public static function initSave()
-	{
-		if (FlxG.save.data.newInput == null)
+    public static function initSave()
+    {
+        if (FlxG.save.data.newInput == null)
 			FlxG.save.data.newInput = true;
 
 		if (FlxG.save.data.downscroll == null)
@@ -13,7 +13,7 @@ class KadeEngineData
 
 		if (FlxG.save.data.dfjk == null)
 			FlxG.save.data.dfjk = 0;
-
+			
 		if (FlxG.save.data.accuracyDisplay == null)
 			FlxG.save.data.accuracyDisplay = true;
 
@@ -41,7 +41,7 @@ class KadeEngineData
 
 		if (FlxG.save.data.fpsCap > 285 || FlxG.save.data.fpsCap < 60)
 			FlxG.save.data.fpsCap = 120; // baby proof so you can't hard lock ur copy of kade engine
-
+		
 		if (FlxG.save.data.scrollSpeed == null)
 			FlxG.save.data.scrollSpeed = 1;
 
@@ -68,7 +68,7 @@ class KadeEngineData
 
 		if (FlxG.save.data.resetButton == null)
 			FlxG.save.data.resetButton = false;
-
+		
 		if (FlxG.save.data.botplay == null)
 			FlxG.save.data.botplay = false;
 
@@ -76,6 +76,6 @@ class KadeEngineData
 
 		Main.watermarks = FlxG.save.data.watermark;
 
-		(cast(Lib.current.getChildAt(0), Main)).setFPSCap(FlxG.save.data.fpsCap);
+		(cast (Lib.current.getChildAt(0), Main)).setFPSCap(FlxG.save.data.fpsCap);
 	}
 }

--- a/source/MainMenuState.hx
+++ b/source/MainMenuState.hx
@@ -15,11 +15,11 @@ import flixel.util.FlxTimer;
 import io.newgrounds.NG;
 import lime.app.Application;
 
+using StringTools;
+
 #if windows
 import Discord.DiscordClient;
 #end
-
-using StringTools;
 
 class MainMenuState extends MusicBeatState
 {
@@ -104,18 +104,21 @@ class MainMenuState extends MusicBeatState
 
 		FlxG.camera.follow(camFollow, null, 0.60 * (60 / FlxG.save.data.fpsCap));
 
-		var versionShit:FlxText = new FlxText(5, FlxG.height - 18, 0, gameVer +  (Main.watermarks ? " FNF - " + kadeEngineVer + " Kade Engine" : ""), 12);
+		var versionShit:FlxText = new FlxText(5, FlxG.height - 18, 0, gameVer + (Main.watermarks ? " FNF - " + kadeEngineVer + " Kade Engine" : ""), 12);
 		versionShit.scrollFactor.set();
 		versionShit.setFormat("VCR OSD Mono", 16, FlxColor.WHITE, LEFT, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
 		add(versionShit);
 
 		// NG.core.calls.event.logEvent('swag').send();
 
-
-		if (FlxG.save.data.dfjk)
-			controls.setKeyboardScheme(KeyboardScheme.Solo, true);
-		else
+		if (FlxG.save.data.dfjk == 0)
 			controls.setKeyboardScheme(KeyboardScheme.Duo(true), true);
+		else if (FlxG.save.data.dfjk == 1)
+			controls.setKeyboardScheme(KeyboardScheme.Solo, true);
+		else if (FlxG.save.data.dfjk == 2)
+			controls.setKeyboardScheme(KeyboardScheme.Qwop, true);
+		else
+			controls.setKeyboardScheme(KeyboardScheme.Spread, true);
 
 		changeItem();
 
@@ -155,7 +158,10 @@ class MainMenuState extends MusicBeatState
 				if (optionShit[curSelected] == 'donate')
 				{
 					#if linux
-					Sys.command('/usr/bin/xdg-open', ["https://www.kickstarter.com/projects/funkin/friday-night-funkin-the-full-ass-game", "&"]);
+					Sys.command('/usr/bin/xdg-open', [
+						"https://www.kickstarter.com/projects/funkin/friday-night-funkin-the-full-ass-game",
+						"&"
+					]);
 					#else
 					FlxG.openURL('https://www.kickstarter.com/projects/funkin/friday-night-funkin-the-full-ass-game');
 					#end
@@ -164,7 +170,7 @@ class MainMenuState extends MusicBeatState
 				{
 					selectedSomethin = true;
 					FlxG.sound.play(Paths.sound('confirmMenu'));
-					
+
 					if (FlxG.save.data.flashing)
 						FlxFlicker.flicker(magenta, 1.1, 0.15, false);
 
@@ -209,7 +215,7 @@ class MainMenuState extends MusicBeatState
 			spr.screenCenter(X);
 		});
 	}
-	
+
 	function goToState()
 	{
 		var daChoice:String = optionShit[curSelected];

--- a/source/MainMenuState.hx
+++ b/source/MainMenuState.hx
@@ -15,11 +15,11 @@ import flixel.util.FlxTimer;
 import io.newgrounds.NG;
 import lime.app.Application;
 
-using StringTools;
-
 #if windows
 import Discord.DiscordClient;
 #end
+
+using StringTools;
 
 class MainMenuState extends MusicBeatState
 {
@@ -104,12 +104,13 @@ class MainMenuState extends MusicBeatState
 
 		FlxG.camera.follow(camFollow, null, 0.60 * (60 / FlxG.save.data.fpsCap));
 
-		var versionShit:FlxText = new FlxText(5, FlxG.height - 18, 0, gameVer + (Main.watermarks ? " FNF - " + kadeEngineVer + " Kade Engine" : ""), 12);
+		var versionShit:FlxText = new FlxText(5, FlxG.height - 18, 0, gameVer +  (Main.watermarks ? " FNF - " + kadeEngineVer + " Kade Engine" : ""), 12);
 		versionShit.scrollFactor.set();
 		versionShit.setFormat("VCR OSD Mono", 16, FlxColor.WHITE, LEFT, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
 		add(versionShit);
 
 		// NG.core.calls.event.logEvent('swag').send();
+
 
 		if (FlxG.save.data.dfjk == 0)
 			controls.setKeyboardScheme(KeyboardScheme.Duo(true), true);
@@ -158,10 +159,7 @@ class MainMenuState extends MusicBeatState
 				if (optionShit[curSelected] == 'donate')
 				{
 					#if linux
-					Sys.command('/usr/bin/xdg-open', [
-						"https://www.kickstarter.com/projects/funkin/friday-night-funkin-the-full-ass-game",
-						"&"
-					]);
+					Sys.command('/usr/bin/xdg-open', ["https://www.kickstarter.com/projects/funkin/friday-night-funkin-the-full-ass-game", "&"]);
 					#else
 					FlxG.openURL('https://www.kickstarter.com/projects/funkin/friday-night-funkin-the-full-ass-game');
 					#end
@@ -170,7 +168,7 @@ class MainMenuState extends MusicBeatState
 				{
 					selectedSomethin = true;
 					FlxG.sound.play(Paths.sound('confirmMenu'));
-
+					
 					if (FlxG.save.data.flashing)
 						FlxFlicker.flicker(magenta, 1.1, 0.15, false);
 
@@ -215,7 +213,7 @@ class MainMenuState extends MusicBeatState
 			spr.screenCenter(X);
 		});
 	}
-
+	
 	function goToState()
 	{
 		var daChoice:String = optionShit[curSelected];

--- a/source/Options.hx
+++ b/source/Options.hx
@@ -1,16 +1,17 @@
 package;
 
-import lime.app.Application;
-import lime.system.DisplayMode;
-import flixel.util.FlxColor;
 import Controls.KeyboardScheme;
 import flixel.FlxG;
-import openfl.display.FPS;
+import flixel.util.FlxColor;
+import lime.app.Application;
+import lime.system.DisplayMode;
 import openfl.Lib;
+import openfl.display.FPS;
 
 class OptionCatagory
 {
 	private var _options:Array<Option> = new Array<Option>();
+
 	public final function getOptions():Array<Option>
 	{
 		return _options;
@@ -21,18 +22,19 @@ class OptionCatagory
 		_options.push(opt);
 	}
 
-	
 	public final function removeOption(opt:Option)
 	{
 		_options.remove(opt);
 	}
 
 	private var _name:String = "New Catagory";
-	public final function getName() {
+
+	public final function getName()
+	{
 		return _name;
 	}
 
-	public function new (catName:String, options:Array<Option>)
+	public function new(catName:String, options:Array<Option>)
 	{
 		_name = catName;
 		_options = options;
@@ -45,9 +47,11 @@ class Option
 	{
 		display = updateDisplay();
 	}
+
 	private var description:String = "";
 	private var display:String;
 	private var acceptValues:Bool = false;
+
 	public final function getDisplay():String
 	{
 		return display;
@@ -63,15 +67,27 @@ class Option
 		return description;
 	}
 
-	
 	// Returns whether the label is to be updated.
-	public function press():Bool { return throw "stub!"; }
-	private function updateDisplay():String { return throw "stub!"; }
-	public function left():Bool { return throw "stub!"; }
-	public function right():Bool { return throw "stub!"; }
+	public function press():Bool
+	{
+		return throw "stub!";
+	}
+
+	private function updateDisplay():String
+	{
+		return throw "stub!";
+	}
+
+	public function left():Bool
+	{
+		return throw "stub!";
+	}
+
+	public function right():Bool
+	{
+		return throw "stub!";
+	}
 }
-
-
 
 class DFJKOption extends Option
 {
@@ -85,12 +101,19 @@ class DFJKOption extends Option
 
 	public override function press():Bool
 	{
-		FlxG.save.data.dfjk = !FlxG.save.data.dfjk;
-		
-		if (FlxG.save.data.dfjk)
-			controls.setKeyboardScheme(KeyboardScheme.Solo, true);
-		else
+		FlxG.save.data.dfjk = FlxG.save.data.dfjk + 1;
+
+		if (FlxG.save.data.dfjk > 3)
+			FlxG.save.data.dfjk = 0;
+
+		if (FlxG.save.data.dfjk == 0)
 			controls.setKeyboardScheme(KeyboardScheme.Duo(true), true);
+		else if (FlxG.save.data.dfjk == 1)
+			controls.setKeyboardScheme(KeyboardScheme.Solo, true);
+		else if (FlxG.save.data.dfjk == 2)
+			controls.setKeyboardScheme(KeyboardScheme.Qwop, true);
+		else
+			controls.setKeyboardScheme(KeyboardScheme.Spread, true);
 
 		display = updateDisplay();
 		return true;
@@ -98,7 +121,14 @@ class DFJKOption extends Option
 
 	private override function updateDisplay():String
 	{
-		return  FlxG.save.data.dfjk ? "DFJK" : "WASD";
+		if (FlxG.save.data.dfjk == 0)
+			return "WASD";
+		else if (FlxG.save.data.dfjk == 1)
+			return "DFJK";
+		else if (FlxG.save.data.dfjk == 2)
+			return "QWOP";
+		else
+			return "Spread";
 	}
 }
 
@@ -151,6 +181,7 @@ class AccuracyOption extends Option
 		super();
 		description = desc;
 	}
+
 	public override function press():Bool
 	{
 		FlxG.save.data.accuracyDisplay = !FlxG.save.data.accuracyDisplay;
@@ -171,6 +202,7 @@ class SongPositionOption extends Option
 		super();
 		description = desc;
 	}
+
 	public override function press():Bool
 	{
 		FlxG.save.data.songPosition = !FlxG.save.data.songPosition;
@@ -191,6 +223,7 @@ class DistractionsAndEffectsOption extends Option
 		super();
 		description = desc;
 	}
+
 	public override function press():Bool
 	{
 		FlxG.save.data.distractions = !FlxG.save.data.distractions;
@@ -211,6 +244,7 @@ class ResetButtonOption extends Option
 		super();
 		description = desc;
 	}
+
 	public override function press():Bool
 	{
 		FlxG.save.data.resetButton = !FlxG.save.data.resetButton;
@@ -231,6 +265,7 @@ class FlashingLightsOption extends Option
 		super();
 		description = desc;
 	}
+
 	public override function press():Bool
 	{
 		FlxG.save.data.flashing = !FlxG.save.data.flashing;
@@ -246,15 +281,13 @@ class FlashingLightsOption extends Option
 
 class Judgement extends Option
 {
-	
-
 	public function new(desc:String)
 	{
 		super();
 		description = desc;
 		acceptValues = true;
 	}
-	
+
 	public override function press():Bool
 	{
 		return true;
@@ -265,8 +298,8 @@ class Judgement extends Option
 		return "Safe Frames";
 	}
 
-	override function left():Bool {
-
+	override function left():Bool
+	{
 		if (Conductor.safeFrames == 1)
 			return false;
 
@@ -275,17 +308,26 @@ class Judgement extends Option
 
 		Conductor.recalculateTimings();
 
-		OptionsMenu.versionShit.text = "Current Safe Frames: " + Conductor.safeFrames + " - Description - " + description + 
-		" - SIK: " + HelperFunctions.truncateFloat(45 * Conductor.timeScale, 0) +
-		"ms GD: " + HelperFunctions.truncateFloat(90 * Conductor.timeScale, 0) +
-		"ms BD: " + HelperFunctions.truncateFloat(135 * Conductor.timeScale, 0) + 
-		"ms SHT: " + HelperFunctions.truncateFloat(155 * Conductor.timeScale, 0) +
-		"ms TOTAL: " + HelperFunctions.truncateFloat(Conductor.safeZoneOffset,0) + "ms";
+		OptionsMenu.versionShit.text = "Current Safe Frames: "
+			+ Conductor.safeFrames
+			+ " - Description - "
+			+ description
+			+ " - SIK: "
+			+ HelperFunctions.truncateFloat(45 * Conductor.timeScale, 0)
+			+ "ms GD: "
+			+ HelperFunctions.truncateFloat(90 * Conductor.timeScale, 0)
+			+ "ms BD: "
+			+ HelperFunctions.truncateFloat(135 * Conductor.timeScale, 0)
+			+ "ms SHT: "
+			+ HelperFunctions.truncateFloat(155 * Conductor.timeScale, 0)
+			+ "ms TOTAL: "
+			+ HelperFunctions.truncateFloat(Conductor.safeZoneOffset, 0)
+			+ "ms";
 		return true;
 	}
 
-	override function right():Bool {
-
+	override function right():Bool
+	{
 		if (Conductor.safeFrames == 20)
 			return false;
 
@@ -294,12 +336,21 @@ class Judgement extends Option
 
 		Conductor.recalculateTimings();
 
-		OptionsMenu.versionShit.text = "Current Safe Frames: " + Conductor.safeFrames + " - Description - " + description + 
-		" - SIK: " + HelperFunctions.truncateFloat(44 * Conductor.timeScale, 0) +
-		"ms GD: " + HelperFunctions.truncateFloat(45 * Conductor.timeScale, 0) +
-		"ms BD: " + HelperFunctions.truncateFloat(90 * Conductor.timeScale, 0) + 
-		"ms SHT: " + HelperFunctions.truncateFloat(135 * Conductor.timeScale, 0) +
-		"ms TOTAL: " + HelperFunctions.truncateFloat(Conductor.safeZoneOffset,0) + "ms";
+		OptionsMenu.versionShit.text = "Current Safe Frames: "
+			+ Conductor.safeFrames
+			+ " - Description - "
+			+ description
+			+ " - SIK: "
+			+ HelperFunctions.truncateFloat(44 * Conductor.timeScale, 0)
+			+ "ms GD: "
+			+ HelperFunctions.truncateFloat(45 * Conductor.timeScale, 0)
+			+ "ms BD: "
+			+ HelperFunctions.truncateFloat(90 * Conductor.timeScale, 0)
+			+ "ms SHT: "
+			+ HelperFunctions.truncateFloat(135 * Conductor.timeScale, 0)
+			+ "ms TOTAL: "
+			+ HelperFunctions.truncateFloat(Conductor.safeZoneOffset, 0)
+			+ "ms";
 		return true;
 	}
 }
@@ -315,7 +366,7 @@ class FPSOption extends Option
 	public override function press():Bool
 	{
 		FlxG.save.data.fps = !FlxG.save.data.fps;
-		(cast (Lib.current.getChildAt(0), Main)).toggleFPS(FlxG.save.data.fps);
+		(cast(Lib.current.getChildAt(0), Main)).toggleFPS(FlxG.save.data.fps);
 		display = updateDisplay();
 		return true;
 	}
@@ -325,8 +376,6 @@ class FPSOption extends Option
 		return "FPS Counter " + (!FlxG.save.data.fps ? "off" : "on");
 	}
 }
-
-
 
 class FPSCapOption extends Option
 {
@@ -346,39 +395,42 @@ class FPSCapOption extends Option
 	{
 		return "FPS Cap";
 	}
-	
-	override function right():Bool {
+
+	override function right():Bool
+	{
 		if (FlxG.save.data.fpsCap >= 290)
 		{
 			FlxG.save.data.fpsCap = 290;
-			(cast (Lib.current.getChildAt(0), Main)).setFPSCap(290);
+			(cast(Lib.current.getChildAt(0), Main)).setFPSCap(290);
 		}
 		else
 			FlxG.save.data.fpsCap = FlxG.save.data.fpsCap + 10;
-		(cast (Lib.current.getChildAt(0), Main)).setFPSCap(FlxG.save.data.fpsCap);
+		(cast(Lib.current.getChildAt(0), Main)).setFPSCap(FlxG.save.data.fpsCap);
 
 		OptionsMenu.versionShit.text = "Current FPS Cap: " + FlxG.save.data.fpsCap + " - Description - " + description;
 
 		return true;
 	}
 
-	override function left():Bool {
+	override function left():Bool
+	{
 		if (FlxG.save.data.fpsCap > 290)
 			FlxG.save.data.fpsCap = 290;
 		else if (FlxG.save.data.fpsCap < 60)
 			FlxG.save.data.fpsCap = Application.current.window.displayMode.refreshRate;
 		else
 			FlxG.save.data.fpsCap = FlxG.save.data.fpsCap - 10;
-		(cast (Lib.current.getChildAt(0), Main)).setFPSCap(FlxG.save.data.fpsCap);
+				(cast(Lib.current.getChildAt(0), Main)).setFPSCap(FlxG.save.data.fpsCap);
 
-		OptionsMenu.versionShit.text = "Current FPS Cap: " + FlxG.save.data.fpsCap + 
-		(FlxG.save.data.fpsCap == Application.current.window.displayMode.refreshRate ? "Hz (Refresh Rate)" : "") 
-		+ " - Description - " + description;
+		OptionsMenu.versionShit.text = "Current FPS Cap: "
+			+ FlxG.save.data.fpsCap
+			+ (FlxG.save.data.fpsCap == Application.current.window.displayMode.refreshRate ? "Hz (Refresh Rate)" : "")
+			+ " - Description - "
+			+ description;
 
 		return true;
 	}
 }
-
 
 class ScrollSpeedOption extends Option
 {
@@ -399,7 +451,8 @@ class ScrollSpeedOption extends Option
 		return "Scroll Speed";
 	}
 
-	override function right():Bool {
+	override function right():Bool
+	{
 		FlxG.save.data.scrollSpeed += 0.1;
 
 		if (FlxG.save.data.scrollSpeed < 1)
@@ -408,11 +461,15 @@ class ScrollSpeedOption extends Option
 		if (FlxG.save.data.scrollSpeed > 10)
 			FlxG.save.data.scrollSpeed = 10;
 
-		OptionsMenu.versionShit.text = "Current Scroll Speed: " + HelperFunctions.truncateFloat(FlxG.save.data.scrollSpeed,1) + " - Description - " + description;
+		OptionsMenu.versionShit.text = "Current Scroll Speed: "
+			+ HelperFunctions.truncateFloat(FlxG.save.data.scrollSpeed, 1)
+			+ " - Description - "
+			+ description;
 		return true;
 	}
 
-	override function left():Bool {
+	override function left():Bool
+	{
 		FlxG.save.data.scrollSpeed -= 0.1;
 
 		if (FlxG.save.data.scrollSpeed < 1)
@@ -421,12 +478,13 @@ class ScrollSpeedOption extends Option
 		if (FlxG.save.data.scrollSpeed > 10)
 			FlxG.save.data.scrollSpeed = 10;
 
-
-		OptionsMenu.versionShit.text = "Current Scroll Speed: " + HelperFunctions.truncateFloat(FlxG.save.data.scrollSpeed,1) + " - Description - " + description;
+		OptionsMenu.versionShit.text = "Current Scroll Speed: "
+			+ HelperFunctions.truncateFloat(FlxG.save.data.scrollSpeed, 1)
+			+ " - Description - "
+			+ description;
 		return true;
 	}
 }
-
 
 class RainbowFPSOption extends Option
 {
@@ -439,7 +497,7 @@ class RainbowFPSOption extends Option
 	public override function press():Bool
 	{
 		FlxG.save.data.fpsRain = !FlxG.save.data.fpsRain;
-		(cast (Lib.current.getChildAt(0), Main)).changeFPSColor(FlxColor.WHITE);
+		(cast(Lib.current.getChildAt(0), Main)).changeFPSColor(FlxColor.WHITE);
 		display = updateDisplay();
 		return true;
 	}
@@ -478,7 +536,7 @@ class ReplayOption extends Option
 		super();
 		description = desc;
 	}
-	
+
 	public override function press():Bool
 	{
 		trace("switch");
@@ -499,7 +557,7 @@ class AccuracyDOption extends Option
 		super();
 		description = desc;
 	}
-	
+
 	public override function press():Bool
 	{
 		FlxG.save.data.accuracyMod = FlxG.save.data.accuracyMod == 1 ? 0 : 1;
@@ -584,6 +642,7 @@ class OffsetMenu extends Option
 		return "Time your offset";
 	}
 }
+
 class BotPlay extends Option
 {
 	public function new(desc:String)
@@ -591,7 +650,7 @@ class BotPlay extends Option
 		super();
 		description = desc;
 	}
-	
+
 	public override function press():Bool
 	{
 		FlxG.save.data.botplay = !FlxG.save.data.botplay;
@@ -599,7 +658,7 @@ class BotPlay extends Option
 		display = updateDisplay();
 		return true;
 	}
-	
+
 	private override function updateDisplay():String
 		return "BotPlay " + (FlxG.save.data.botplay ? "on" : "off");
 }

--- a/source/Options.hx
+++ b/source/Options.hx
@@ -1,17 +1,16 @@
 package;
 
-import Controls.KeyboardScheme;
-import flixel.FlxG;
-import flixel.util.FlxColor;
 import lime.app.Application;
 import lime.system.DisplayMode;
-import openfl.Lib;
+import flixel.util.FlxColor;
+import Controls.KeyboardScheme;
+import flixel.FlxG;
 import openfl.display.FPS;
+import openfl.Lib;
 
 class OptionCatagory
 {
 	private var _options:Array<Option> = new Array<Option>();
-
 	public final function getOptions():Array<Option>
 	{
 		return _options;
@@ -22,19 +21,18 @@ class OptionCatagory
 		_options.push(opt);
 	}
 
+	
 	public final function removeOption(opt:Option)
 	{
 		_options.remove(opt);
 	}
 
 	private var _name:String = "New Catagory";
-
-	public final function getName()
-	{
+	public final function getName() {
 		return _name;
 	}
 
-	public function new(catName:String, options:Array<Option>)
+	public function new (catName:String, options:Array<Option>)
 	{
 		_name = catName;
 		_options = options;
@@ -47,11 +45,9 @@ class Option
 	{
 		display = updateDisplay();
 	}
-
 	private var description:String = "";
 	private var display:String;
 	private var acceptValues:Bool = false;
-
 	public final function getDisplay():String
 	{
 		return display;
@@ -67,27 +63,15 @@ class Option
 		return description;
 	}
 
+	
 	// Returns whether the label is to be updated.
-	public function press():Bool
-	{
-		return throw "stub!";
-	}
-
-	private function updateDisplay():String
-	{
-		return throw "stub!";
-	}
-
-	public function left():Bool
-	{
-		return throw "stub!";
-	}
-
-	public function right():Bool
-	{
-		return throw "stub!";
-	}
+	public function press():Bool { return throw "stub!"; }
+	private function updateDisplay():String { return throw "stub!"; }
+	public function left():Bool { return throw "stub!"; }
+	public function right():Bool { return throw "stub!"; }
 }
+
+
 
 class DFJKOption extends Option
 {
@@ -181,7 +165,6 @@ class AccuracyOption extends Option
 		super();
 		description = desc;
 	}
-
 	public override function press():Bool
 	{
 		FlxG.save.data.accuracyDisplay = !FlxG.save.data.accuracyDisplay;
@@ -202,7 +185,6 @@ class SongPositionOption extends Option
 		super();
 		description = desc;
 	}
-
 	public override function press():Bool
 	{
 		FlxG.save.data.songPosition = !FlxG.save.data.songPosition;
@@ -223,7 +205,6 @@ class DistractionsAndEffectsOption extends Option
 		super();
 		description = desc;
 	}
-
 	public override function press():Bool
 	{
 		FlxG.save.data.distractions = !FlxG.save.data.distractions;
@@ -244,7 +225,6 @@ class ResetButtonOption extends Option
 		super();
 		description = desc;
 	}
-
 	public override function press():Bool
 	{
 		FlxG.save.data.resetButton = !FlxG.save.data.resetButton;
@@ -265,7 +245,6 @@ class FlashingLightsOption extends Option
 		super();
 		description = desc;
 	}
-
 	public override function press():Bool
 	{
 		FlxG.save.data.flashing = !FlxG.save.data.flashing;
@@ -281,13 +260,15 @@ class FlashingLightsOption extends Option
 
 class Judgement extends Option
 {
+	
+
 	public function new(desc:String)
 	{
 		super();
 		description = desc;
 		acceptValues = true;
 	}
-
+	
 	public override function press():Bool
 	{
 		return true;
@@ -298,8 +279,8 @@ class Judgement extends Option
 		return "Safe Frames";
 	}
 
-	override function left():Bool
-	{
+	override function left():Bool {
+
 		if (Conductor.safeFrames == 1)
 			return false;
 
@@ -308,26 +289,17 @@ class Judgement extends Option
 
 		Conductor.recalculateTimings();
 
-		OptionsMenu.versionShit.text = "Current Safe Frames: "
-			+ Conductor.safeFrames
-			+ " - Description - "
-			+ description
-			+ " - SIK: "
-			+ HelperFunctions.truncateFloat(45 * Conductor.timeScale, 0)
-			+ "ms GD: "
-			+ HelperFunctions.truncateFloat(90 * Conductor.timeScale, 0)
-			+ "ms BD: "
-			+ HelperFunctions.truncateFloat(135 * Conductor.timeScale, 0)
-			+ "ms SHT: "
-			+ HelperFunctions.truncateFloat(155 * Conductor.timeScale, 0)
-			+ "ms TOTAL: "
-			+ HelperFunctions.truncateFloat(Conductor.safeZoneOffset, 0)
-			+ "ms";
+		OptionsMenu.versionShit.text = "Current Safe Frames: " + Conductor.safeFrames + " - Description - " + description + 
+		" - SIK: " + HelperFunctions.truncateFloat(45 * Conductor.timeScale, 0) +
+		"ms GD: " + HelperFunctions.truncateFloat(90 * Conductor.timeScale, 0) +
+		"ms BD: " + HelperFunctions.truncateFloat(135 * Conductor.timeScale, 0) + 
+		"ms SHT: " + HelperFunctions.truncateFloat(155 * Conductor.timeScale, 0) +
+		"ms TOTAL: " + HelperFunctions.truncateFloat(Conductor.safeZoneOffset,0) + "ms";
 		return true;
 	}
 
-	override function right():Bool
-	{
+	override function right():Bool {
+
 		if (Conductor.safeFrames == 20)
 			return false;
 
@@ -336,21 +308,12 @@ class Judgement extends Option
 
 		Conductor.recalculateTimings();
 
-		OptionsMenu.versionShit.text = "Current Safe Frames: "
-			+ Conductor.safeFrames
-			+ " - Description - "
-			+ description
-			+ " - SIK: "
-			+ HelperFunctions.truncateFloat(44 * Conductor.timeScale, 0)
-			+ "ms GD: "
-			+ HelperFunctions.truncateFloat(45 * Conductor.timeScale, 0)
-			+ "ms BD: "
-			+ HelperFunctions.truncateFloat(90 * Conductor.timeScale, 0)
-			+ "ms SHT: "
-			+ HelperFunctions.truncateFloat(135 * Conductor.timeScale, 0)
-			+ "ms TOTAL: "
-			+ HelperFunctions.truncateFloat(Conductor.safeZoneOffset, 0)
-			+ "ms";
+		OptionsMenu.versionShit.text = "Current Safe Frames: " + Conductor.safeFrames + " - Description - " + description + 
+		" - SIK: " + HelperFunctions.truncateFloat(44 * Conductor.timeScale, 0) +
+		"ms GD: " + HelperFunctions.truncateFloat(45 * Conductor.timeScale, 0) +
+		"ms BD: " + HelperFunctions.truncateFloat(90 * Conductor.timeScale, 0) + 
+		"ms SHT: " + HelperFunctions.truncateFloat(135 * Conductor.timeScale, 0) +
+		"ms TOTAL: " + HelperFunctions.truncateFloat(Conductor.safeZoneOffset,0) + "ms";
 		return true;
 	}
 }
@@ -366,7 +329,7 @@ class FPSOption extends Option
 	public override function press():Bool
 	{
 		FlxG.save.data.fps = !FlxG.save.data.fps;
-		(cast(Lib.current.getChildAt(0), Main)).toggleFPS(FlxG.save.data.fps);
+		(cast (Lib.current.getChildAt(0), Main)).toggleFPS(FlxG.save.data.fps);
 		display = updateDisplay();
 		return true;
 	}
@@ -376,6 +339,8 @@ class FPSOption extends Option
 		return "FPS Counter " + (!FlxG.save.data.fps ? "off" : "on");
 	}
 }
+
+
 
 class FPSCapOption extends Option
 {
@@ -395,42 +360,39 @@ class FPSCapOption extends Option
 	{
 		return "FPS Cap";
 	}
-
-	override function right():Bool
-	{
+	
+	override function right():Bool {
 		if (FlxG.save.data.fpsCap >= 290)
 		{
 			FlxG.save.data.fpsCap = 290;
-			(cast(Lib.current.getChildAt(0), Main)).setFPSCap(290);
+			(cast (Lib.current.getChildAt(0), Main)).setFPSCap(290);
 		}
 		else
 			FlxG.save.data.fpsCap = FlxG.save.data.fpsCap + 10;
-		(cast(Lib.current.getChildAt(0), Main)).setFPSCap(FlxG.save.data.fpsCap);
+		(cast (Lib.current.getChildAt(0), Main)).setFPSCap(FlxG.save.data.fpsCap);
 
 		OptionsMenu.versionShit.text = "Current FPS Cap: " + FlxG.save.data.fpsCap + " - Description - " + description;
 
 		return true;
 	}
 
-	override function left():Bool
-	{
+	override function left():Bool {
 		if (FlxG.save.data.fpsCap > 290)
 			FlxG.save.data.fpsCap = 290;
 		else if (FlxG.save.data.fpsCap < 60)
 			FlxG.save.data.fpsCap = Application.current.window.displayMode.refreshRate;
 		else
 			FlxG.save.data.fpsCap = FlxG.save.data.fpsCap - 10;
-				(cast(Lib.current.getChildAt(0), Main)).setFPSCap(FlxG.save.data.fpsCap);
+		(cast (Lib.current.getChildAt(0), Main)).setFPSCap(FlxG.save.data.fpsCap);
 
-		OptionsMenu.versionShit.text = "Current FPS Cap: "
-			+ FlxG.save.data.fpsCap
-			+ (FlxG.save.data.fpsCap == Application.current.window.displayMode.refreshRate ? "Hz (Refresh Rate)" : "")
-			+ " - Description - "
-			+ description;
+		OptionsMenu.versionShit.text = "Current FPS Cap: " + FlxG.save.data.fpsCap + 
+		(FlxG.save.data.fpsCap == Application.current.window.displayMode.refreshRate ? "Hz (Refresh Rate)" : "") 
+		+ " - Description - " + description;
 
 		return true;
 	}
 }
+
 
 class ScrollSpeedOption extends Option
 {
@@ -451,8 +413,7 @@ class ScrollSpeedOption extends Option
 		return "Scroll Speed";
 	}
 
-	override function right():Bool
-	{
+	override function right():Bool {
 		FlxG.save.data.scrollSpeed += 0.1;
 
 		if (FlxG.save.data.scrollSpeed < 1)
@@ -461,15 +422,11 @@ class ScrollSpeedOption extends Option
 		if (FlxG.save.data.scrollSpeed > 10)
 			FlxG.save.data.scrollSpeed = 10;
 
-		OptionsMenu.versionShit.text = "Current Scroll Speed: "
-			+ HelperFunctions.truncateFloat(FlxG.save.data.scrollSpeed, 1)
-			+ " - Description - "
-			+ description;
+		OptionsMenu.versionShit.text = "Current Scroll Speed: " + HelperFunctions.truncateFloat(FlxG.save.data.scrollSpeed,1) + " - Description - " + description;
 		return true;
 	}
 
-	override function left():Bool
-	{
+	override function left():Bool {
 		FlxG.save.data.scrollSpeed -= 0.1;
 
 		if (FlxG.save.data.scrollSpeed < 1)
@@ -478,13 +435,12 @@ class ScrollSpeedOption extends Option
 		if (FlxG.save.data.scrollSpeed > 10)
 			FlxG.save.data.scrollSpeed = 10;
 
-		OptionsMenu.versionShit.text = "Current Scroll Speed: "
-			+ HelperFunctions.truncateFloat(FlxG.save.data.scrollSpeed, 1)
-			+ " - Description - "
-			+ description;
+
+		OptionsMenu.versionShit.text = "Current Scroll Speed: " + HelperFunctions.truncateFloat(FlxG.save.data.scrollSpeed,1) + " - Description - " + description;
 		return true;
 	}
 }
+
 
 class RainbowFPSOption extends Option
 {
@@ -497,7 +453,7 @@ class RainbowFPSOption extends Option
 	public override function press():Bool
 	{
 		FlxG.save.data.fpsRain = !FlxG.save.data.fpsRain;
-		(cast(Lib.current.getChildAt(0), Main)).changeFPSColor(FlxColor.WHITE);
+		(cast (Lib.current.getChildAt(0), Main)).changeFPSColor(FlxColor.WHITE);
 		display = updateDisplay();
 		return true;
 	}
@@ -536,7 +492,7 @@ class ReplayOption extends Option
 		super();
 		description = desc;
 	}
-
+	
 	public override function press():Bool
 	{
 		trace("switch");
@@ -557,7 +513,7 @@ class AccuracyDOption extends Option
 		super();
 		description = desc;
 	}
-
+	
 	public override function press():Bool
 	{
 		FlxG.save.data.accuracyMod = FlxG.save.data.accuracyMod == 1 ? 0 : 1;
@@ -642,7 +598,6 @@ class OffsetMenu extends Option
 		return "Time your offset";
 	}
 }
-
 class BotPlay extends Option
 {
 	public function new(desc:String)
@@ -650,7 +605,7 @@ class BotPlay extends Option
 		super();
 		description = desc;
 	}
-
+	
 	public override function press():Bool
 	{
 		FlxG.save.data.botplay = !FlxG.save.data.botplay;
@@ -658,7 +613,7 @@ class BotPlay extends Option
 		display = updateDisplay();
 		return true;
 	}
-
+	
 	private override function updateDisplay():String
 		return "BotPlay " + (FlxG.save.data.botplay ? "on" : "off");
 }


### PR DESCRIPTION
Changed `FlxG.save.data.dfjk` from a bool to an int. Saving still works and will also load properly if controls were already DFJK before this.

0 = WASD
1 = DFJK
2 = QWOP
3 = Spread (ZX12 (The only option))