### PR TITLE
result screen loop fix

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2697,7 +2697,7 @@ class PlayState extends MusicBeatState
 				if (FlxG.save.data.scoreScreen)
 					openSubState(new ResultsScreen());
 				else
-					FlxG.switchState(new PlayState());
+					FlxG.switchState(new FreeplayState());
 			}
 		}
 	}


### PR DESCRIPTION
if result screen was turned off and played under freeplay it would load up the playstate again instead of sending the player directly back to the freeplay menu