### PR TITLE
move week names to file

### DIFF
--- a/assets/preload/data/weekNames.txt
+++ b/assets/preload/data/weekNames.txt
@@ -1,0 +1,7 @@
+Tutorial
+Daddy Dearest
+Spooky Month
+PICO
+MOMMY MUST MURDER
+RED SNOW
+Hating Simulator ft. Moawling

--- a/docs/guides/weeks.md
+++ b/docs/guides/weeks.md
@@ -103,32 +103,21 @@ var weekCharacters:Array<Dynamic> = [
 
 ### Step 4. Week Names
 
-Underneath the song list, there should be another array called `weekNames`. Creating a new line in that array, just enter a string that represents what you want the week to be called.
+In `assets/preload/data`, there should be a .txt file called `weekNames`. Creating a new line in that file, just enter a string that represents what you want the week to be called.
 
 Example
 ---
 
 ---
-```haxe
-var weekNames:Array<String> = [
-		
-	"How to Funk",
-		
-	"Daddy dearest",
-		
-	"Spooky Month",
-		
-	"PICO",
-		
-	"Mommy Must Murder",
-		
-	"Red Snow",
-		
-	"Hating Simulator ft. Moawlings",
-    		
-	"Tankman"
-	
-];
+```
+Tutorial
+Daddy Dearest
+Spooky Month
+PICO
+MOMMY MUST MURDER
+RED SNOW
+Hating Simulator ft. Moawling
+TANKMAN
 ```
 
 ---
@@ -137,7 +126,7 @@ var weekNames:Array<String> = [
   
 ### Step 5. Graphics
   
-Displaying a week icon for your custom week is as simple as dropping a .png into `assets/images/storymenu`. Rename the file to `week7.png`, `week8.png`, etc.
+Displaying a week icon for your custom week is as simple as dropping a .png into `assets/preload/images/storymenu`. Rename the file to `week7.png`, `week8.png`, etc.
 
 Example
 ---

--- a/source/StoryMenuState.hx
+++ b/source/StoryMenuState.hx
@@ -46,15 +46,7 @@ class StoryMenuState extends MusicBeatState
 		['senpai', 'bf', 'gf']
 	];
 
-	var weekNames:Array<String> = [
-		"",
-		"Daddy Dearest",
-		"Spooky Month",
-		"PICO",
-		"MOMMY MUST MURDER",
-		"RED SNOW",
-		"Hating Simulator ft. Moawling"
-	];
+	var weekNames:Array<String> = CoolUtil.coolTextFile(Paths.txt('weekNames'));
 
 	var txtWeekTitle:FlxText;
 


### PR DESCRIPTION
pretty much does what #895 did except it only moves the week names

allows custom week names in b-sides to show up

![2021-06-21_11-09-52_Kade_Engine](https://user-images.githubusercontent.com/15317421/122808210-6f9b6080-d281-11eb-9033-33c8423c232e.png)

the custom week guide has been updated to accomodate for the file change (will probably also have to be pushed to `move-wiki-to-site` branch if this PR is merged)