### PR TITLE
stupid wrong icon Health fix

### DIFF
--- a/source/ModchartState.hx
+++ b/source/ModchartState.hx
@@ -250,7 +250,7 @@ class ModchartState
 					PlayState.instance.removeObject(PlayState.boyfriend);
 					PlayState.boyfriend = new Boyfriend(oldboyfriendx, oldboyfriendy, id);
 					PlayState.instance.addObject(PlayState.boyfriend);
-					PlayState.instance.iconP2.animation.play(id);
+					PlayState.instance.iconP1.animation.play(id);
 	}
 
 	function makeAnimatedLuaSprite(spritePath:String,names:Array<String>,prefixes:Array<String>,startAnim:String, id:String)


### PR DESCRIPTION
I'm guessing KadeDev copies the changeDadCharacter and changes any dad character variable to boyfriend character in changeBoyfriendCharacter without noticing he didnt yet changed the iconP2