### PR TITLE
load character offsets from file

### DIFF
--- a/assets/shared/images/characters/bf-carOffsets.txt
+++ b/assets/shared/images/characters/bf-carOffsets.txt
@@ -1,0 +1,9 @@
+idle -5 0
+singUP -29 27
+singRIGHT -38 -7
+singLEFT 12 -6
+singDOWN -10 -50
+singUPmiss -29 27
+singRIGHTmiss -30 21
+singLEFTmiss 12 24
+singDOWNmiss -11 -19

--- a/assets/shared/images/characters/bf-christmasOffsets.txt
+++ b/assets/shared/images/characters/bf-christmasOffsets.txt
@@ -1,0 +1,10 @@
+idle -5 0
+singUP -29 27
+singRIGHT -38 -7
+singLEFT 12 -6
+singDOWN -10 -50
+singUPmiss -29 27
+singRIGHTmiss -30 21
+singLEFTmiss 12 24
+singDOWNmiss -11 -19
+hey 7 4

--- a/assets/shared/images/characters/bf-pixel-deadOffsets.txt
+++ b/assets/shared/images/characters/bf-pixel-deadOffsets.txt
@@ -1,0 +1,3 @@
+firstDeath 0 0
+deathLoop -30 -12
+deathConfirm -30 -12

--- a/assets/shared/images/characters/bf-pixelOffsets.txt
+++ b/assets/shared/images/characters/bf-pixelOffsets.txt
@@ -1,0 +1,9 @@
+idle 0 0
+singUP 0 0
+singRIGHT 0 0
+singLEFT 0 0
+singDOWN 0 0
+singUPmiss 0 0
+singRIGHTmiss 0 0
+singLEFTmiss 0 0
+singDOWNmiss 0 0

--- a/assets/shared/images/characters/bfOffsets.txt
+++ b/assets/shared/images/characters/bfOffsets.txt
@@ -1,0 +1,14 @@
+idle -5 0
+singUP -29 27
+singRIGHT -38 -7
+singLEFT 12 -6
+singDOWN -10 -50
+singUPmiss -29 27
+singRIGHTmiss -30 21
+singLEFTmiss 12 24
+singDOWNmiss -11 -19
+hey 7 4
+firstDeath 37 11
+deathLoop 37 5
+deathConfirm 37 69
+scared -4 0

--- a/assets/shared/images/characters/bfPixelsDEAD.xml
+++ b/assets/shared/images/characters/bfPixelsDEAD.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TextureAtlas imagePath="bfPixelsDEAD.png">
-	<!-- Created with Adobe Animate version 20.0.0.17400 -->
-	<!-- http://www.adobe.com/products/animate.html -->
+	<!-- if you read this you're epic. -->
+	<!-- manual tweaks done on BF Dies pixel last 2 frames -->
 	<SubTexture name="BF Dies pixel0000" x="0" y="0" width="90" height="81"/>
 	<SubTexture name="BF Dies pixel0001" x="100" y="0" width="90" height="81"/>
 	<SubTexture name="BF Dies pixel0002" x="200" y="0" width="90" height="81"/>
@@ -58,8 +58,8 @@
 	<SubTexture name="BF Dies pixel0053" x="300" y="273" width="90" height="81"/>
 	<SubTexture name="BF Dies pixel0054" x="400" y="273" width="90" height="81"/>
 	<SubTexture name="BF Dies pixel0055" x="500" y="273" width="90" height="81"/>
-	<SubTexture name="BF Dies pixel0056" x="696" y="450" width="77" height="76"/>
-	<SubTexture name="BF Dies pixel0057" x="696" y="450" width="77" height="76"/>
+	<SubTexture name="BF Dies pixel0056" x="691" y="448" width="90" height="81"/>
+	<SubTexture name="BF Dies pixel0057" x="691" y="448" width="90" height="81"/>
 	<SubTexture name="RETRY CONFIRM0000" x="600" y="273" width="77" height="76"/>
 	<SubTexture name="RETRY CONFIRM0001" x="687" y="273" width="77" height="76"/>
 	<SubTexture name="RETRY CONFIRM0002" x="687" y="273" width="77" height="76"/>

--- a/assets/shared/images/characters/dadOffsets.txt
+++ b/assets/shared/images/characters/dadOffsets.txt
@@ -1,0 +1,5 @@
+idle 0 0
+singUP -6 50
+singRIGHT 0 27
+singLEFT -10 10
+singDOWN 0 -30

--- a/assets/shared/images/characters/gf-carOffsets.txt
+++ b/assets/shared/images/characters/gf-carOffsets.txt
@@ -1,0 +1,2 @@
+danceLeft 0 0
+danceRight 0 0

--- a/assets/shared/images/characters/gf-christmasOffsets.txt
+++ b/assets/shared/images/characters/gf-christmasOffsets.txt
@@ -1,0 +1,11 @@
+cheer 0 0
+sad -2 -21
+danceLeft 0 -9
+danceRight 0 -9
+singUP 0 4
+singRIGHT 0 -20
+singLEFT 0 -19
+singDOWN 0 -20
+hairBlow 45 -8
+hairFall 0 -9
+scared -2 -17

--- a/assets/shared/images/characters/gf-pixelOffsets.txt
+++ b/assets/shared/images/characters/gf-pixelOffsets.txt
@@ -1,0 +1,2 @@
+danceLeft 0 0
+danceRight 0 0

--- a/assets/shared/images/characters/gfOffsets.txt
+++ b/assets/shared/images/characters/gfOffsets.txt
@@ -1,0 +1,11 @@
+cheer 0 0
+sad -2 -21
+danceLeft 0 -9
+danceRight 0 -9
+singUP 0 4
+singRIGHT 0 -20
+singLEFT 0 -19
+singDOWN 0 -20
+hairBlow 45 -8
+hairFall 0 -9
+scared -2 -17

--- a/assets/shared/images/characters/mom-carOffsets.txt
+++ b/assets/shared/images/characters/mom-carOffsets.txt
@@ -1,0 +1,5 @@
+idle 0 0
+singUP 14 71
+singRIGHT 10 -60
+singLEFT 250 -23
+singDOWN 20 -160

--- a/assets/shared/images/characters/momOffsets.txt
+++ b/assets/shared/images/characters/momOffsets.txt
@@ -1,0 +1,5 @@
+idle 0 0
+singUP 14 71
+singRIGHT 10 -60
+singLEFT 250 -23
+singDOWN 20 -160

--- a/assets/shared/images/characters/monster-christmasOffsets.txt
+++ b/assets/shared/images/characters/monster-christmasOffsets.txt
@@ -1,0 +1,5 @@
+idle 0 0
+singUP -20 50
+singRIGHT -51 0
+singLEFT -30 0
+singDOWN -40 -94

--- a/assets/shared/images/characters/monsterOffsets.txt
+++ b/assets/shared/images/characters/monsterOffsets.txt
@@ -1,0 +1,5 @@
+idle 0 0
+singUP -20 94
+singRIGHT -51 30
+singLEFT -30 20
+singDOWN -50 -80

--- a/assets/shared/images/characters/parents-christmasOffsets.txt
+++ b/assets/shared/images/characters/parents-christmasOffsets.txt
@@ -1,0 +1,9 @@
+idle 0 0
+singUP -47 24
+singRIGHT -1 -23
+singLEFT -30 16
+singDOWN -31 -29
+singUP-alt -47 24
+singRIGHT-alt -1 -24
+singLEFT-alt -30 15
+singDOWN-alt -30 -27

--- a/assets/shared/images/characters/picoOffsets.txt
+++ b/assets/shared/images/characters/picoOffsets.txt
@@ -1,0 +1,9 @@
+idle 0 0
+singUP -29 27
+singRIGHT -68 -7
+singLEFT 65 9
+singDOWN 200 -70
+singUPmiss -19 67
+singRIGHTmiss -60 41
+singLEFTmiss 62 64
+singDOWNmiss 210 -28

--- a/assets/shared/images/characters/senpai-angryOffsets.txt
+++ b/assets/shared/images/characters/senpai-angryOffsets.txt
@@ -1,0 +1,5 @@
+idle 0 0
+singUP 5 37
+singRIGHT 0 0
+singLEFT 40 0
+singDOWN 14 0

--- a/assets/shared/images/characters/senpaiOffsets.txt
+++ b/assets/shared/images/characters/senpaiOffsets.txt
@@ -1,0 +1,5 @@
+idle 0 0
+singUP 5 37
+singRIGHT 0 0
+singLEFT 40 0
+singDOWN 14 0

--- a/assets/shared/images/characters/spiritOffsets.txt
+++ b/assets/shared/images/characters/spiritOffsets.txt
@@ -1,0 +1,5 @@
+idle -220 -280
+singUP -220 -240
+singRIGHT -220 -280
+singLEFT -200 -280
+singDOWN 170 110

--- a/assets/shared/images/characters/spookyOffsets.txt
+++ b/assets/shared/images/characters/spookyOffsets.txt
@@ -1,0 +1,6 @@
+danceLeft 0 0
+danceRight 0 0
+singUP -20 26
+singRIGHT -130 -14
+singLEFT 130 -10
+singDOWN -50 -130

--- a/source/Character.hx
+++ b/source/Character.hx
@@ -46,19 +46,7 @@ class Character extends FlxSprite
 				animation.addByIndices('hairFall', "GF Dancing Beat Hair Landing", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], "", 24, false);
 				animation.addByPrefix('scared', 'GF FEAR', 24);
 
-				addOffset('cheer');
-				addOffset('sad', -2, -2);
-				addOffset('danceLeft', 0, -9);
-				addOffset('danceRight', 0, -9);
-
-				addOffset("singUP", 0, 4);
-				addOffset("singRIGHT", 0, -20);
-				addOffset("singLEFT", 0, -19);
-				addOffset("singDOWN", 0, -20);
-				addOffset('hairBlow', 45, -8);
-				addOffset('hairFall', 0, -9);
-
-				addOffset('scared', -2, -17);
+				loadOffsetFile(curCharacter);
 
 				playAnim('danceRight');
 
@@ -77,19 +65,7 @@ class Character extends FlxSprite
 				animation.addByIndices('hairFall', "GF Dancing Beat Hair Landing", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], "", 24, false);
 				animation.addByPrefix('scared', 'GF FEAR', 24);
 
-				addOffset('cheer');
-				addOffset('sad', -2, -2);
-				addOffset('danceLeft', 0, -9);
-				addOffset('danceRight', 0, -9);
-
-				addOffset("singUP", 0, 4);
-				addOffset("singRIGHT", 0, -20);
-				addOffset("singLEFT", 0, -19);
-				addOffset("singDOWN", 0, -20);
-				addOffset('hairBlow', 45, -8);
-				addOffset('hairFall', 0, -9);
-
-				addOffset('scared', -2, -17);
+				loadOffsetFile(curCharacter);
 
 				playAnim('danceRight');
 
@@ -101,8 +77,7 @@ class Character extends FlxSprite
 				animation.addByIndices('danceRight', 'GF Dancing Beat Hair blowing CAR', [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29], "", 24,
 					false);
 
-				addOffset('danceLeft', 0);
-				addOffset('danceRight', 0);
+				loadOffsetFile(curCharacter);
 
 				playAnim('danceRight');
 
@@ -113,8 +88,7 @@ class Character extends FlxSprite
 				animation.addByIndices('danceLeft', 'GF IDLE', [30, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], "", 24, false);
 				animation.addByIndices('danceRight', 'GF IDLE', [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29], "", 24, false);
 
-				addOffset('danceLeft', 0);
-				addOffset('danceRight', 0);
+				loadOffsetFile(curCharacter);
 
 				playAnim('danceRight');
 
@@ -132,11 +106,7 @@ class Character extends FlxSprite
 				animation.addByPrefix('singDOWN', 'Dad Sing Note DOWN', 24);
 				animation.addByPrefix('singLEFT', 'Dad Sing Note LEFT', 24);
 
-				addOffset('idle');
-				addOffset("singUP", -6, 50);
-				addOffset("singRIGHT", 0, 27);
-				addOffset("singLEFT", -10, 10);
-				addOffset("singDOWN", 0, -30);
+				loadOffsetFile(curCharacter);
 
 				playAnim('idle');
 			case 'spooky':
@@ -149,13 +119,7 @@ class Character extends FlxSprite
 				animation.addByIndices('danceLeft', 'spooky dance idle', [0, 2, 6], "", 12, false);
 				animation.addByIndices('danceRight', 'spooky dance idle', [8, 10, 12, 14], "", 12, false);
 
-				addOffset('danceLeft');
-				addOffset('danceRight');
-
-				addOffset("singUP", -20, 26);
-				addOffset("singRIGHT", -130, -14);
-				addOffset("singLEFT", 130, -10);
-				addOffset("singDOWN", -50, -130);
+				loadOffsetFile(curCharacter);
 
 				playAnim('danceRight');
 			case 'mom':
@@ -170,11 +134,7 @@ class Character extends FlxSprite
 				// CUZ DAVE IS DUMB!
 				animation.addByPrefix('singRIGHT', 'Mom Pose Left', 24, false);
 
-				addOffset('idle');
-				addOffset("singUP", 14, 71);
-				addOffset("singRIGHT", 10, -60);
-				addOffset("singLEFT", 250, -23);
-				addOffset("singDOWN", 20, -160);
+				loadOffsetFile(curCharacter);
 
 				playAnim('idle');
 
@@ -190,11 +150,7 @@ class Character extends FlxSprite
 				// CUZ DAVE IS DUMB!
 				animation.addByPrefix('singRIGHT', 'Mom Pose Left', 24, false);
 
-				addOffset('idle');
-				addOffset("singUP", 14, 71);
-				addOffset("singRIGHT", 10, -60);
-				addOffset("singLEFT", 250, -23);
-				addOffset("singDOWN", 20, -160);
+				loadOffsetFile(curCharacter);
 
 				playAnim('idle');
 			case 'monster':
@@ -206,11 +162,7 @@ class Character extends FlxSprite
 				animation.addByPrefix('singLEFT', 'Monster left note', 24, false);
 				animation.addByPrefix('singRIGHT', 'Monster Right note', 24, false);
 
-				addOffset('idle');
-				addOffset("singUP", -20, 50);
-				addOffset("singRIGHT", -51);
-				addOffset("singLEFT", -30);
-				addOffset("singDOWN", -30, -40);
+				loadOffsetFile(curCharacter);
 				playAnim('idle');
 			case 'monster-christmas':
 				tex = Paths.getSparrowAtlas('characters/monsterChristmas');
@@ -221,11 +173,7 @@ class Character extends FlxSprite
 				animation.addByPrefix('singLEFT', 'Monster left note', 24, false);
 				animation.addByPrefix('singRIGHT', 'Monster Right note', 24, false);
 
-				addOffset('idle');
-				addOffset("singUP", -20, 50);
-				addOffset("singRIGHT", -51);
-				addOffset("singLEFT", -30);
-				addOffset("singDOWN", -40, -94);
+				loadOffsetFile(curCharacter);
 				playAnim('idle');
 			case 'pico':
 				tex = Paths.getSparrowAtlas('characters/Pico_FNF_assetss');
@@ -252,15 +200,7 @@ class Character extends FlxSprite
 				animation.addByPrefix('singUPmiss', 'pico Up note miss', 24);
 				animation.addByPrefix('singDOWNmiss', 'Pico Down Note MISS', 24);
 
-				addOffset('idle');
-				addOffset("singUP", -29, 27);
-				addOffset("singRIGHT", -68, -7);
-				addOffset("singLEFT", 65, 9);
-				addOffset("singDOWN", 200, -70);
-				addOffset("singUPmiss", -19, 67);
-				addOffset("singRIGHTmiss", -60, 41);
-				addOffset("singLEFTmiss", 62, 64);
-				addOffset("singDOWNmiss", 210, -28);
+				loadOffsetFile(curCharacter);
 
 				playAnim('idle');
 
@@ -289,20 +229,7 @@ class Character extends FlxSprite
 
 				animation.addByPrefix('scared', 'BF idle shaking', 24);
 
-				addOffset('idle', -5);
-				addOffset("singUP", -29, 27);
-				addOffset("singRIGHT", -38, -7);
-				addOffset("singLEFT", 12, -6);
-				addOffset("singDOWN", -10, -50);
-				addOffset("singUPmiss", -29, 27);
-				addOffset("singRIGHTmiss", -30, 21);
-				addOffset("singLEFTmiss", 12, 24);
-				addOffset("singDOWNmiss", -11, -19);
-				addOffset("hey", 7, 4);
-				addOffset('firstDeath', 37, 11);
-				addOffset('deathLoop', 37, 5);
-				addOffset('deathConfirm', 37, 69);
-				addOffset('scared', -4);
+				loadOffsetFile(curCharacter);
 
 				playAnim('idle');
 
@@ -322,16 +249,7 @@ class Character extends FlxSprite
 				animation.addByPrefix('singDOWNmiss', 'BF NOTE DOWN MISS', 24, false);
 				animation.addByPrefix('hey', 'BF HEY', 24, false);
 
-				addOffset('idle', -5);
-				addOffset("singUP", -29, 27);
-				addOffset("singRIGHT", -38, -7);
-				addOffset("singLEFT", 12, -6);
-				addOffset("singDOWN", -10, -50);
-				addOffset("singUPmiss", -29, 27);
-				addOffset("singRIGHTmiss", -30, 21);
-				addOffset("singLEFTmiss", 12, 24);
-				addOffset("singDOWNmiss", -11, -19);
-				addOffset("hey", 7, 4);
+				loadOffsetFile(curCharacter);
 
 				playAnim('idle');
 
@@ -349,15 +267,7 @@ class Character extends FlxSprite
 				animation.addByPrefix('singRIGHTmiss', 'BF NOTE RIGHT MISS', 24, false);
 				animation.addByPrefix('singDOWNmiss', 'BF NOTE DOWN MISS', 24, false);
 
-				addOffset('idle', -5);
-				addOffset("singUP", -29, 27);
-				addOffset("singRIGHT", -38, -7);
-				addOffset("singLEFT", 12, -6);
-				addOffset("singDOWN", -10, -50);
-				addOffset("singUPmiss", -29, 27);
-				addOffset("singRIGHTmiss", -30, 21);
-				addOffset("singLEFTmiss", 12, 24);
-				addOffset("singDOWNmiss", -11, -19);
+				loadOffsetFile(curCharacter);
 				playAnim('idle');
 
 				flipX = true;
@@ -373,15 +283,7 @@ class Character extends FlxSprite
 				animation.addByPrefix('singRIGHTmiss', 'BF RIGHT MISS', 24, false);
 				animation.addByPrefix('singDOWNmiss', 'BF DOWN MISS', 24, false);
 
-				addOffset('idle');
-				addOffset("singUP");
-				addOffset("singRIGHT");
-				addOffset("singLEFT");
-				addOffset("singDOWN");
-				addOffset("singUPmiss");
-				addOffset("singRIGHTmiss");
-				addOffset("singLEFTmiss");
-				addOffset("singDOWNmiss");
+				loadOffsetFile(curCharacter);
 
 				setGraphicSize(Std.int(width * 6));
 				updateHitbox();
@@ -402,9 +304,7 @@ class Character extends FlxSprite
 				animation.addByPrefix('deathConfirm', "RETRY CONFIRM", 24, false);
 				animation.play('firstDeath');
 
-				addOffset('firstDeath');
-				addOffset('deathLoop', -37);
-				addOffset('deathConfirm', -37);
+				loadOffsetFile(curCharacter);
 				playAnim('firstDeath');
 				// pixel bullshit
 				setGraphicSize(Std.int(width * 6));
@@ -420,11 +320,7 @@ class Character extends FlxSprite
 				animation.addByPrefix('singRIGHT', 'SENPAI RIGHT NOTE', 24, false);
 				animation.addByPrefix('singDOWN', 'SENPAI DOWN NOTE', 24, false);
 
-				addOffset('idle');
-				addOffset("singUP", 5, 37);
-				addOffset("singRIGHT");
-				addOffset("singLEFT", 40);
-				addOffset("singDOWN", 14);
+				loadOffsetFile(curCharacter);
 
 				playAnim('idle');
 
@@ -440,11 +336,7 @@ class Character extends FlxSprite
 				animation.addByPrefix('singRIGHT', 'Angry Senpai RIGHT NOTE', 24, false);
 				animation.addByPrefix('singDOWN', 'Angry Senpai DOWN NOTE', 24, false);
 
-				addOffset('idle');
-				addOffset("singUP", 5, 37);
-				addOffset("singRIGHT");
-				addOffset("singLEFT", 40);
-				addOffset("singDOWN", 14);
+				loadOffsetFile(curCharacter);
 				playAnim('idle');
 
 				setGraphicSize(Std.int(width * 6));
@@ -460,11 +352,7 @@ class Character extends FlxSprite
 				animation.addByPrefix('singLEFT', "left_", 24, false);
 				animation.addByPrefix('singDOWN', "spirit down_", 24, false);
 
-				addOffset('idle', -220, -280);
-				addOffset('singUP', -220, -240);
-				addOffset("singRIGHT", -220, -280);
-				addOffset("singLEFT", -200, -280);
-				addOffset("singDOWN", 170, 110);
+				loadOffsetFile(curCharacter);
 
 				setGraphicSize(Std.int(width * 6));
 				updateHitbox();
@@ -487,15 +375,7 @@ class Character extends FlxSprite
 				animation.addByPrefix('singLEFT-alt', 'Parent Left Note Mom', 24, false);
 				animation.addByPrefix('singRIGHT-alt', 'Parent Right Note Mom', 24, false);
 
-				addOffset('idle');
-				addOffset("singUP", -47, 24);
-				addOffset("singRIGHT", -1, -23);
-				addOffset("singLEFT", -30, 16);
-				addOffset("singDOWN", -31, -29);
-				addOffset("singUP-alt", -47, 24);
-				addOffset("singRIGHT-alt", -1, -24);
-				addOffset("singLEFT-alt", -30, 15);
-				addOffset("singDOWN-alt", -30, -27);
+				loadOffsetFile(curCharacter);
 
 				playAnim('idle');
 		}

--- a/source/Character.hx
+++ b/source/Character.hx
@@ -525,6 +525,17 @@ class Character extends FlxSprite
 		}
 	}
 
+	public function loadOffsetFile(character:String)
+	{
+		var offset:Array<String> = CoolUtil.coolTextFile(Paths.txt('images/characters/' + character + "Offsets"));
+
+		for (i in 0...offset.length)
+		{
+			var data:Array<String> = offset[i].split(' ');
+			addOffset(data[0], Std.parseInt(data[1]), Std.parseInt(data[2]));
+		}
+	}
+
 	override function update(elapsed:Float)
 	{
 		if (!curCharacter.startsWith('bf'))

--- a/source/ChartingState.hx
+++ b/source/ChartingState.hx
@@ -309,10 +309,10 @@ class ChartingState extends MusicBeatState
 			shiftNotes(Std.int(stepperShiftNoteDial.value),Std.int(stepperShiftNoteDialstep.value),Std.int(stepperShiftNoteDialms.value));
 		});
 
-		var characters:Array<String> = CoolUtil.coolTextFile(Paths.txt('characterList'));
-		var gfVersions:Array<String> = CoolUtil.coolTextFile(Paths.txt('gfVersionList'));
-		var stages:Array<String> = CoolUtil.coolTextFile(Paths.txt('stageList'));
-		var noteStyles:Array<String> = CoolUtil.coolTextFile(Paths.txt('noteStyleList'));
+		var characters:Array<String> = CoolUtil.coolTextFile(Paths.txt('data/characterList'));
+		var gfVersions:Array<String> = CoolUtil.coolTextFile(Paths.txt('data/gfVersionList'));
+		var stages:Array<String> = CoolUtil.coolTextFile(Paths.txt('data/stageList'));
+		var noteStyles:Array<String> = CoolUtil.coolTextFile(Paths.txt('data/noteStyleList'));
 
 		var player1DropDown = new FlxUIDropDownMenu(10, 100, FlxUIDropDownMenu.makeStrIdLabelArray(characters, true), function(character:String)
 		{

--- a/source/FreeplayState.hx
+++ b/source/FreeplayState.hx
@@ -56,7 +56,7 @@ class FreeplayState extends MusicBeatState
 
 	override function create()
 	{
-		var initSonglist = CoolUtil.coolTextFile(Paths.txt('freeplaySonglist'));
+		var initSonglist = CoolUtil.coolTextFile(Paths.txt('data/freeplaySonglist'));
 
 		//var diffList = "";
 

--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -67,7 +67,7 @@ class Paths
 
 	inline static public function txt(key:String, ?library:String)
 	{
-		return getPath('data/$key.txt', TEXT, library);
+		return getPath('$key.txt', TEXT, library);
 	}
 
 	inline static public function xml(key:String, ?library:String)

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -362,11 +362,11 @@ class PlayState extends MusicBeatState
 					"Only then I will even CONSIDER letting you\ndate my daughter!"
 				];
 			case 'senpai':
-				dialogue = CoolUtil.coolTextFile(Paths.txt('senpai/senpaiDialogue'));
+				dialogue = CoolUtil.coolTextFile(Paths.txt('data/senpai/senpaiDialogue'));
 			case 'roses':
-				dialogue = CoolUtil.coolTextFile(Paths.txt('roses/rosesDialogue'));
+				dialogue = CoolUtil.coolTextFile(Paths.txt('data/roses/rosesDialogue'));
 			case 'thorns':
-				dialogue = CoolUtil.coolTextFile(Paths.txt('thorns/thornsDialogue'));
+				dialogue = CoolUtil.coolTextFile(Paths.txt('data/thorns/thornsDialogue'));
 		}
 
 		//defaults if no stage was found in chart

--- a/source/TitleState.hx
+++ b/source/TitleState.hx
@@ -239,7 +239,7 @@ class TitleState extends MusicBeatState
 
 	function getIntroTextShit():Array<Array<String>>
 	{
-		var fullText:String = Assets.getText(Paths.txt('introText'));
+		var fullText:String = Assets.getText(Paths.txt('data/introText'));
 
 		var firstArray:Array<String> = fullText.split('\n');
 		var swagGoodArray:Array<Array<String>> = [];


### PR DESCRIPTION
this unhardcodes the character offsets by loading them from a file instead of code in the executable

instead of having to modify code and compile the game:
```haxe
addOffset('danceLeft');
addOffset('danceRight');
addOffset("singUP", -20, 26);
addOffset("singRIGHT", -130, -14);
addOffset("singLEFT", 130, -10);
addOffset("singDOWN", -50, -130);
```
you now can just modify a text file and boot up the game:
```
danceLeft 0 0
danceRight 0 0
singUP -20 26
singRIGHT -130 -14
singLEFT 130 -10
singDOWN -50 -130
```

for people creating character swap mods that needed custom offsets, this means you no longer have to modify the xml or recompile the game

i did this mainly for coding practice, but also to allow for more versatile modding

also includes v0.2.8 offset fixes for pixel bf's death (he no longer shifts around)

https://user-images.githubusercontent.com/15317421/124213118-e23be580-daa4-11eb-85fc-d3f50bab8e48.mp4

