### PR TITLE
remove desktop check for appearance and fps counter options

### DIFF
--- a/source/OptionsMenu.hx
+++ b/source/OptionsMenu.hx
@@ -42,18 +42,16 @@ class OptionsMenu extends MusicBeatState
 		new OptionCategory("Appearance", [
 			new DistractionsAndEffectsOption("Toggle stage distractions that can hinder your gameplay."),
 			new CamZoomOption("Toggle the camera zoom in-game."),
-			#if desktop
 			new RainbowFPSOption("Make the FPS Counter Rainbow"),
 			new AccuracyOption("Display accuracy information."),
 			new NPSDisplayOption("Shows your current Notes Per Second."),
 			new SongPositionOption("Show the songs current position (as a bar)"),
 			new CpuStrums("CPU's strumline lights up when a note hits it."),
-			#end
 		]),
 		
 		new OptionCategory("Misc", [
-			#if desktop
 			new FPSOption("Toggle the FPS Counter"),
+			#if desktop
 			new ReplayOption("View replays"),
 			#end
 			new FlashingLightsOption("Toggle flashing lights that can cause epileptic seizures and strain."),


### PR DESCRIPTION
removes the desktop check that was mentioned in #829 
fps cap and replays are still disabled tho

![2021-07-01_20-51-03_msedge](https://user-images.githubusercontent.com/15317421/124217919-0e0f9900-daae-11eb-9c2e-cab36060ecec.png)
