### PR TITLE
fix opponent idle anim desync/freeze

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -3916,6 +3916,10 @@ class PlayState extends MusicBeatState
 			boyfriend.playAnim('idle');
 		}
 		
+		if (!dad.animation.curAnim.name.startsWith("sing"))
+		{
+			dad.dance();
+		}
 
 		if (curBeat % 8 == 7 && curSong == 'Bopeebo')
 		{


### PR DESCRIPTION
remaking this because kade merged it into stable last time, reverted it, and forgot to fix it on master :(

fixes opponent idle animations desyncing from the music and freezing on camera focus. this used to be here but was removed in 1.5.4 for whatever reason.