### PR TITLE
Make da title screen bump in sync

### DIFF
--- a/source/TitleState.hx
+++ b/source/TitleState.hx
@@ -175,7 +175,7 @@ class TitleState extends MusicBeatState
 			logoBl = new FlxSprite(-150, -100);
 			logoBl.frames = Paths.getSparrowAtlas('KadeEngineLogoBumpin');
 			logoBl.antialiasing = true;
-			logoBl.animation.addByPrefix('bump', 'logo bumpin', 24);
+			logoBl.animation.addByPrefix('bump', 'logo bumpin', 24, false);
 			logoBl.animation.play('bump');
 			logoBl.updateHitbox();
 			// logoBl.screenCenter();
@@ -388,6 +388,7 @@ class TitleState extends MusicBeatState
 	{
 		super.beatHit();
 
+		logoBl.animation.finish();
 		logoBl.animation.play('bump');
 		danceLeft = !danceLeft;
 


### PR DESCRIPTION
Title screen no bump in sync, cause it loops before the next beat hits
this thingy fixes that by just disabling it to loop, and finishing the animation right before it bumps again so it bumps every beat.

pogers