### PR TITLE
Sync story mode menu to the beat

### DIFF
--- a/source/MenuCharacter.hx
+++ b/source/MenuCharacter.hx
@@ -1,6 +1,7 @@
 package;
 
 import flixel.FlxSprite;
+import flixel.FlxG;
 import flixel.graphics.frames.FlxAtlasFrames;
 
 class CharacterSetting
@@ -33,6 +34,10 @@ class MenuCharacter extends FlxSprite
 	];
 
 	private var flipped:Bool = false;
+	//questionable variable name lmfao
+	private var goesLeftNRight:Bool = false;
+	private var danceLeft:Bool = false;
+	private var character:String = '';
 
 	public function new(x:Int, y:Int, scale:Float, flipped:Bool)
 	{
@@ -43,15 +48,17 @@ class MenuCharacter extends FlxSprite
 
 		frames = Paths.getSparrowAtlas('campaign_menu_UI_characters');
 
-		animation.addByPrefix('bf', "BF idle dance white", 24);
+		animation.addByPrefix('bf', "BF idle dance white", 24, false);
 		animation.addByPrefix('bfConfirm', 'BF HEY!!', 24, false);
-		animation.addByPrefix('gf', "GF Dancing Beat WHITE", 24);
-		animation.addByPrefix('dad', "Dad idle dance BLACK LINE", 24);
-		animation.addByPrefix('spooky', "spooky dance idle BLACK LINES", 24);
-		animation.addByPrefix('pico', "Pico Idle Dance", 24);
-		animation.addByPrefix('mom', "Mom Idle BLACK LINES", 24);
-		animation.addByPrefix('parents-christmas', "Parent Christmas Idle", 24);
-		animation.addByPrefix('senpai', "SENPAI idle Black Lines", 24);
+		animation.addByIndices('gf-left', 'GF Dancing Beat WHITE', [30, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], "", 24, false);
+		animation.addByIndices('gf-right', 'GF Dancing Beat WHITE', [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29], "", 24, false);
+		animation.addByPrefix('dad', "Dad idle dance BLACK LINE", 24, false);
+		animation.addByIndices('spooky-left', 'spooky dance idle BLACK LINES', [0, 2, 6], "", 12, false);
+		animation.addByIndices('spooky-right', 'spooky dance idle BLACK LINES', [8, 10, 12, 14], "", 12, false);
+		animation.addByPrefix('pico', "Pico Idle Dance", 24, false);
+		animation.addByPrefix('mom', "Mom Idle BLACK LINES", 24, false);
+		animation.addByPrefix('parents-christmas', "Parent Christmas Idle", 24, false);
+		animation.addByPrefix('senpai', "SENPAI idle Black Lines", 24, false);
 
 		setGraphicSize(Std.int(width * scale));
 		updateHitbox();
@@ -59,6 +66,8 @@ class MenuCharacter extends FlxSprite
 
 	public function setCharacter(character:String):Void
 	{
+		var sameCharacter:Bool = character == this.character;
+		this.character = character;
 		if (character == '')
 		{
 			visible = false;
@@ -69,11 +78,31 @@ class MenuCharacter extends FlxSprite
 			visible = true;
 		}
 
-		animation.play(character);
+		if (!sameCharacter) {
+			bopHead(true);
+		}
 
 		var setting:CharacterSetting = settings[character];
 		offset.set(setting.x, setting.y);
 		setGraphicSize(Std.int(width * setting.scale));
 		flipX = setting.flipped != flipped;
+	}
+
+	public function bopHead(LastFrame:Bool = false):Void
+	{
+		if (character == 'gf' || character == 'spooky') {
+			danceLeft = !danceLeft;
+
+		if (danceLeft)
+			animation.play(character + "-left", true);
+		else
+			animation.play(character + "-right", true);
+		} else {
+			//no spooky nor girlfriend so we do da normal animation
+			animation.play(character, true);
+		}
+		if (LastFrame) {
+			animation.finish();
+		}
 	}
 }

--- a/source/MenuCharacter.hx
+++ b/source/MenuCharacter.hx
@@ -93,12 +93,14 @@ class MenuCharacter extends FlxSprite
 		if (character == 'gf' || character == 'spooky') {
 			danceLeft = !danceLeft;
 
-		if (danceLeft)
-			animation.play(character + "-left", true);
-		else
-			animation.play(character + "-right", true);
+			if (danceLeft)
+				animation.play(character + "-left", true);
+			else
+				animation.play(character + "-right", true);
 		} else {
 			//no spooky nor girlfriend so we do da normal animation
+			if (animation.name == "bfConfirm")
+				return;
 			animation.play(character, true);
 		}
 		if (LastFrame) {

--- a/source/StoryMenuState.hx
+++ b/source/StoryMenuState.hx
@@ -323,6 +323,9 @@ class StoryMenuState extends MusicBeatState
 			FlxG.switchState(new MainMenuState());
 		}
 
+		if (FlxG.sound.music != null)
+			Conductor.songPosition = FlxG.sound.music.time;
+
 		super.update(elapsed);
 	}
 
@@ -473,5 +476,14 @@ class StoryMenuState extends MusicBeatState
 
 		FlxG.save.data.weekUnlocked = weekUnlocked.length - 1;
 		FlxG.save.flush();
+	}
+
+	override function beatHit()
+	{
+		super.beatHit();
+
+		grpWeekCharacters.members[0].bopHead();
+		grpWeekCharacters.members[1].bopHead();
+		grpWeekCharacters.members[2].bopHead();
 	}
 }


### PR DESCRIPTION
Pretty simple, just makes the outlines of the characters on the story mode menu bop their head to the music, just looks cool and more polished 😎

basically just calls a bopHead function in MenuCharacter when beatHit triggers, which then just plays the animation, also some polishing where if a new character comes in it stays on the last frame till the next beat hits and when a character thats already on screen gets repicked it doesnt trigger the animation again.