### PR TITLE
Ability to flip character in offset test menu

### DIFF
--- a/source/AnimationDebug.hx
+++ b/source/AnimationDebug.hx
@@ -118,6 +118,9 @@ class AnimationDebug extends FlxState
 		if (FlxG.keys.justPressed.Q)
 			FlxG.camera.zoom -= 0.25;
 
+		if (FlxG.keys.justPressed.F)
+			char.flipX = !char.flipX;
+
 		if (FlxG.keys.pressed.I || FlxG.keys.pressed.J || FlxG.keys.pressed.K || FlxG.keys.pressed.L)
 		{
 			if (FlxG.keys.pressed.I)


### PR DESCRIPTION
Useful if character is being flipped in the code and offset looks weird when adjusting it at sprites original rotation(For example tankman sprites, looks normal when adjusted for left-facing sprite, but completely off for right-facing)