### PR TITLE
Allows offsets to be loaded outside "shared" library

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# More Information on Contributing to Kade Engine
+
+## Branches
+`stable` is the repository's main branch, so people can clone a stable Kade Engine to work on their mods. However, this means that Pull Requests will default to merge into
+`stable` instead of `master`.
+
+### If your pull request changes the engine, it merges into MASTER.
+### If your pull request changes the website, it merges into STABLE.
+
+This really took this long to document. Why?

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 ![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/KadeDev/Kade-Engine/latest) ![GitHub repo size](https://img.shields.io/github/repo-size/KadeDev/Kade-Engine) ![Lines of code](https://img.shields.io/tokei/lines/github/KadeDev/Kade-Engine) ![Supported platforms](https://img.shields.io/badge/supported%20platforms-windows%2C%20macOS%2C%20linux%2C%20html5-blue) ![GitHub all releases](https://img.shields.io/github/downloads/KadeDev/Kade-Engine/total) ![GitHub](https://img.shields.io/github/license/KadeDev/Kade-Engine) ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/KadeDev/Kade-Engine?include_prereleases&label=latest%20version) 
 
 # Friday Night Funkin': Kade Engine
+
+### If you want to contribute to Kade Engine, read [this](https://github.com/KadeDev/Kade-Engine/blob/stable/CONTRIBUTING.md) first.
+
 ## Friday Night Funkin'
 **Friday Night Funkin'** is a rhythm game originally made for Ludum Dare 47 "Stuck In a Loop".
 
@@ -69,6 +72,7 @@ This game was made with love to Newgrounds and its community. Extra love to Tom 
 ### Kade Engine
 - [KadeDeveloper](https://twitter.com/KadeDeveloper) - Maintainer and lead programmer
 - [The contributors](https://github.com/KadeDev/Kade-Engine/graphs/contributors)
+
 
 
 ### Shoutouts

--- a/source/Character.hx
+++ b/source/Character.hx
@@ -408,9 +408,9 @@ class Character extends FlxSprite
 		}
 	}
 
-	public function loadOffsetFile(character:String)
+	public function loadOffsetFile(character:String, library:String = 'shared')
 	{
-		var offset:Array<String> = CoolUtil.coolTextFile(Paths.txt('images/characters/' + character + "Offsets", 'shared'));
+		var offset:Array<String> = CoolUtil.coolTextFile(Paths.txt('images/characters/' + character + "Offsets", library));
 
 		for (i in 0...offset.length)
 		{


### PR DESCRIPTION
Since we can load in characters other than the shared libary, why not the offsets too?