### PR TITLE
building guide had the wrong path

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -62,4 +62,5 @@ Finally, we are ready to build.
 
 - Run `lime build <target>`, replacing `<target>` with the platform you want to build to (`windows`, `mac`, `linux`, `html5`) (i.e. `lime build windows`)
 - The build will be in `Kade-Engine/export/release/<target>/bin`, with `<target>` being the target you built to in the previous step. (i.e. `Kade-Engine/export/release/windows/bin`)
+- Incase you added the -debug flag the files will be inside `Kade-Engine/export/debug/<target>/bin`
 - Only the `bin` folder is necessary to run the game. The other ones in `export/release/<target>` are not.

--- a/docs/building.md
+++ b/docs/building.md
@@ -61,5 +61,5 @@ Since you already installed `git` in a previous step, we'll use it to clone the 
 Finally, we are ready to build.
 
 - Run `lime build <target>`, replacing `<target>` with the platform you want to build to (`windows`, `mac`, `linux`, `html5`) (i.e. `lime build windows`)
-- The build will be in `Kade-Engine/export/<target>/bin`, with `<target>` being the target you built to in the previous step. (i.e. `Kade-Engine/export/windows/bin`)
-- Only the `bin` folder is necessary to run the game. The other ones in `export/<target>` are not.
+- The build will be in `Kade-Engine/export/release/<target>/bin`, with `<target>` being the target you built to in the previous step. (i.e. `Kade-Engine/export/release/windows/bin`)
+- Only the `bin` folder is necessary to run the game. The other ones in `export/release/<target>` are not.


### PR DESCRIPTION
it said the path is `export/<target>/bin`
but the correct path is `export/release/<target>/bin`
![image](https://user-images.githubusercontent.com/57607350/128424121-c70b374f-5081-48e4-9028-c06e28b11b83.png)
