### PR TITLE
Remove conversion of keycodes in playstate / Fixed not being to use some binds

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1538,7 +1538,7 @@ class PlayState extends MusicBeatState
 	private function releaseInput(evt:KeyboardEvent):Void // handles releases
 	{
 		@:privateAccess
-		var key = FlxKey.toStringMap.get(Keyboard.__convertKeyCode(evt.keyCode));
+		var key = FlxKey.toStringMap.get(evt.keyCode);
 
 		var binds:Array<String> = [
 			FlxG.save.data.leftBind,
@@ -1587,7 +1587,7 @@ class PlayState extends MusicBeatState
 		// this makes it work for special characters
 
 		@:privateAccess
-		var key = FlxKey.toStringMap.get(Keyboard.__convertKeyCode(evt.keyCode));
+		var key = FlxKey.toStringMap.get(evt.keyCode);
 
 		var binds:Array<String> = [
 			FlxG.save.data.leftBind,


### PR DESCRIPTION
It seems these keycodes are already converted? I'm not sure, but this fixes a bug where you can't bind some keys, for example try rebinding up arrow to right and vice versa, it will not work in-game as it's converting it to wrong keys, for example up is converted to the quote (') key.

If the fix isn't good then I'll make it into an issue, I don't have experience in Haxe. 