### PR TITLE
Improved keybinds menu

### DIFF
--- a/source/KeyBindMenu.hx
+++ b/source/KeyBindMenu.hx
@@ -342,6 +342,13 @@ class KeyBindMenu extends FlxSubState
                 }
             }
 
+        if (notAllowed.contains(r))
+        {
+            gpKeys[curSelected] = tempKey;
+            lastKey = r;
+            return;
+        }
+
         if(shouldReturn){
             if (swapKey != -1) {
                 gpKeys[swapKey] = tempKey;
@@ -384,9 +391,9 @@ class KeyBindMenu extends FlxSubState
                 }
             }
 
-        if (r.contains("NUMPAD"))
+        if (r.contains("NUMPAD") || notAllowed.contains(r))
         {
-            keys[curSelected] = null;
+            keys[curSelected] = tempKey;
             lastKey = r;
             return;
         }

--- a/source/KeyBindMenu.hx
+++ b/source/KeyBindMenu.hx
@@ -182,8 +182,10 @@ class KeyBindMenu extends FlxSubState
             case "input":
                 tempKey = keys[curSelected];
                 keys[curSelected] = "?";
-                if (KeyBinds.gamepad)
+                if (KeyBinds.gamepad) {
+                    tempKey = gpKeys[curSelected];
                     gpKeys[curSelected] = "?";
+                }
                 textUpdate();
                 state = "waiting";
 

--- a/source/KeyBindMenu.hx
+++ b/source/KeyBindMenu.hx
@@ -324,12 +324,15 @@ class KeyBindMenu extends FlxSubState
         var shouldReturn:Bool = true;
 
         var notAllowed:Array<String> = ["START"];
+        var swapKey:Int = -1;
 
         for(x in 0...gpKeys.length)
             {
                 var oK = gpKeys[x];
-                if(oK == r)
+                if(oK == r) {
+                    swapKey = x;
                     gpKeys[x] = null;
+                }
                 if (notAllowed.contains(oK))
                 {
                     gpKeys[x] = null;
@@ -339,6 +342,9 @@ class KeyBindMenu extends FlxSubState
             }
 
         if(shouldReturn){
+            if (swapKey != -1) {
+                gpKeys[swapKey] = tempKey;
+            }
             gpKeys[curSelected] = r;
             FlxG.sound.play(Paths.sound('scrollMenu'));
         }
@@ -356,6 +362,7 @@ class KeyBindMenu extends FlxSubState
         var shouldReturn:Bool = true;
 
         var notAllowed:Array<String> = [];
+        var swapKey:Int = -1;
 
         for(x in blacklist){notAllowed.push(x);}
 
@@ -364,8 +371,10 @@ class KeyBindMenu extends FlxSubState
         for(x in 0...keys.length)
             {
                 var oK = keys[x];
-                if(oK == r)
+                if(oK == r) {
+                    swapKey = x;
                     keys[x] = null;
+                }
                 if (notAllowed.contains(oK))
                 {
                     keys[x] = null;
@@ -384,6 +393,10 @@ class KeyBindMenu extends FlxSubState
         lastKey = "";
 
         if(shouldReturn){
+            // Swap keys instead of setting the other one as null
+            if (swapKey != -1) {
+                keys[swapKey] = tempKey;
+            }
             keys[curSelected] = r;
             FlxG.sound.play(Paths.sound('scrollMenu'));
         }

--- a/source/KeyBindMenu.hx
+++ b/source/KeyBindMenu.hx
@@ -180,11 +180,12 @@ class KeyBindMenu extends FlxSubState
                 }
 
             case "input":
-                tempKey = keys[curSelected];
-                keys[curSelected] = "?";
                 if (KeyBinds.gamepad) {
                     tempKey = gpKeys[curSelected];
                     gpKeys[curSelected] = "?";
+                } else {
+                    tempKey = keys[curSelected];
+                    keys[curSelected] = "?";
                 }
                 textUpdate();
                 state = "waiting";


### PR DESCRIPTION
- Keys will now swap instead of resetting the other key, same as in the NG version of the game.
- Fixed setting gamepad controls resetting the keyboard one
- Fixed being able to set blacklisted keys (they'd reset when an additional key would be set, but otherwise the game still allow you to set them)
- Trying to use blacklisted keys will no longer reset your key, instead it will just keep it as it was.