### PR TITLE
Astraphobia Trigger Option

### DIFF
--- a/source/KadeEngineData.hx
+++ b/source/KadeEngineData.hx
@@ -72,6 +72,9 @@ class KadeEngineData
 
 		if (FlxG.save.data.distractions == null)
 			FlxG.save.data.distractions = true;
+
+	    	if (FlxG.save.data.astraphobia == null)
+			FlxG.save.data.astraphobia = true;
 		
 		if (FlxG.save.data.stepMania == null)
 			FlxG.save.data.stepMania = false;

--- a/source/ModchartState.hx
+++ b/source/ModchartState.hx
@@ -396,6 +396,7 @@ class ModchartState
 				setVar("downscroll", FlxG.save.data.downscroll);
 				setVar("flashing", FlxG.save.data.flashing);
 				setVar("distractions", FlxG.save.data.distractions);
+	    			setVar("astraphobia", FlxG.save.data.astraphobia);
 	
 				setVar("curStep", 0);
 				setVar("curBeat", 0);

--- a/source/Options.hx
+++ b/source/Options.hx
@@ -278,7 +278,7 @@ class Astraphobia extends Option
 	{
 		FlxG.save.data.astraphobia = !FlxG.save.astraphobia;
 		display = updateDisplay();
-		return true:
+		return true;
 	}
 
 	private override function updateDisplay():String

--- a/source/Options.hx
+++ b/source/Options.hx
@@ -285,6 +285,7 @@ class Astraphobia extends Option
 	{
 		return "Astraphobia Triggers " + (!FlxG.save.data.astraphobia ? "off" : "on");
 	}
+}
 
 class StepManiaOption extends Option
 {

--- a/source/Options.hx
+++ b/source/Options.hx
@@ -953,6 +953,7 @@ class ResetSettings extends Option
 		FlxG.save.data.watermark = null;
 		FlxG.save.data.ghost = null;
 		FlxG.save.data.distractions = null;
+		FlxG.save.data.astraphobia = null;
 		FlxG.save.data.stepMania = null;
 		FlxG.save.data.flashing = null;
 		FlxG.save.data.resetButton = null;

--- a/source/Options.hx
+++ b/source/Options.hx
@@ -267,6 +267,25 @@ class DistractionsAndEffectsOption extends Option
 	}
 }
 
+class Astraphobia extends Option
+{
+	public function new(desc:String)
+	{
+		super();
+		description = desc;
+	}
+	public override function press():Bool
+	{
+		FlxG.save.data.astraphobia = !FlxG.save.astraphobia;
+		display = updateDisplay();
+		return true:
+	}
+
+	private override function updateDisplay():String
+	{
+		return "Astraphobia Triggers " + (!FlxG.save.data.astraphobia ? "off" : "on");
+	}
+
 class StepManiaOption extends Option
 {
 	public function new(desc:String)

--- a/source/OptionsMenu.hx
+++ b/source/OptionsMenu.hx
@@ -43,6 +43,7 @@ class OptionsMenu extends MusicBeatState
 		new OptionCategory("Appearance", [
 			new EditorRes("Not showing the editor grid will greatly increase editor performance"),
 			new DistractionsAndEffectsOption("Toggle stage distractions that can hinder your gameplay."),
+			new Astraphobia("Toggle Week 2's thunder sounds and screen animations"),
 			new CamZoomOption("Toggle the camera zoom in-game."),
 			new StepManiaOption("Sets the colors of the arrows depending on quantization instead of direction."),
 			new AccuracyOption("Display accuracy information on the info bar."),

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -4503,14 +4503,17 @@ class PlayState extends MusicBeatState
 
 	function lightningStrikeShit():Void
 	{
-		FlxG.sound.play(Paths.soundRandom('thunder_', 1, 2));
-		halloweenBG.animation.play('lightning');
+		if(FlxG.save.data.astraphobia) 
+		{
+			FlxG.sound.play(Paths.soundRandom('thunder_', 1, 2));
+			halloweenBG.animation.play('lightning');
 
-		lightningStrikeBeat = curBeat;
-		lightningOffset = FlxG.random.int(8, 24);
+			lightningStrikeBeat = curBeat;
+			lightningOffset = FlxG.random.int(8, 24);
 
-		boyfriend.playAnim('scared', true);
-		gf.playAnim('scared', true);
+			boyfriend.playAnim('scared', true);
+			gf.playAnim('scared', true);
+		}
 	}
 
 	var danced:Bool = false;


### PR DESCRIPTION
Astraphobia, is the fear of thunderstorms ranging from a simple few roars of thunder to intense crashing and rumbling beneath one's feet. This option is toggleable within the options menu and the only thing it does is stop the thunder and lighting effects that Week 2 gives off for those who may be a little ill toward thunderstorms, it is automatically on as the option is called "Astraphobia Triggers (On/Off)" The option is on as it means that the effects that can trigger the attacks of one are, at the moment, on.