### PR TITLE
Add new modchart functions to switch GF character, and BF/Dad health icons.

### DIFF
--- a/source/ModchartState.hx
+++ b/source/ModchartState.hx
@@ -253,6 +253,24 @@ class ModchartState
 					PlayState.instance.iconP1.changeIcon(id);
 	}
 
+	function changeBoyfriendHealthIcon(id:String)
+	{
+					PlayState.instance.iconP1.changeIcon(id);
+	}
+
+	function changeDadHealthIcon(id:String)
+	{
+					PlayState.instance.iconP2.changeIcon(id);
+	}
+
+	function changeGirlfriendCharacter(id:String) {
+						var oldgirlfriendx = PlayState.gf.x;
+						var oldgirlfriendy = PlayState.gf.y;
+						PlayState.instance.removeObject(PlayState.gf);
+						PlayState.gf = new Character(oldgirlfriendx, oldgirlfriendy, id);
+						PlayState.instance.addObject(PlayState.gf);
+	}
+
 	function makeAnimatedLuaSprite(spritePath:String,names:Array<String>,prefixes:Array<String>,startAnim:String, id:String)
 	{
 		#if sys
@@ -435,6 +453,12 @@ class ModchartState
 				Lua_helper.add_callback(lua,"changeDadCharacter", changeDadCharacter);
 
 				Lua_helper.add_callback(lua,"changeBoyfriendCharacter", changeBoyfriendCharacter);
+
+				Lua_helper.add_callback(lua,"changeBoyfriendHealthIcon", changeBoyfriendHealthIcon);
+
+				Lua_helper.add_callback(lua,"changeDadHealthIcon", changeDadHealthIcon);
+
+				Lua_helper.add_callback(lua,"changeGirlfriendCharacter", changeGirlfriendCharacter);
 	
 				Lua_helper.add_callback(lua,"getProperty", getPropertyByName);
 				


### PR DESCRIPTION
Added three new Misc functions for modcharts.

Name | Arguments | Description
-- | -- | --
changeBoyfriendHealthIcon|Character ID|Replaces the health icon for the player without replacing the character.
changeDadHealthIcon|Character ID|Replaces the health icon for the enemy without replacing the character.
changeGirlfriendCharacter|Character ID|Replaces the girlfriend character.

Example modchart:

```
function update(elapsed)
    if curStep == 100 then
        -- Enable wind.
        setGirlfriendCharacter("gf-car")
    end
end
```

Known bugs:

- [ ] Performance drop when switching between Girlfriend characters (also seen with the existing setDadCharacter method).
- [ ] If you call `changeDadCharacter` on the same frame as `changeDadHealthIcon`, the latter call will be overridden by the former. The workaround is to call `changeDadHealthIcon` one frame later.