### PR TITLE
fix bf's animation during botplay and glow player strums during replay

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -4208,13 +4208,30 @@ class PlayState extends MusicBeatState
 						if (n != null)
 						{
 							goodNoteHit(daNote);
-							boyfriend.holdTimer = daNote.sustainLength;
+							boyfriend.holdTimer = 0;
+							if (FlxG.save.data.cpuStrums)
+							{
+								playerStrums.forEach(function(spr:StaticArrow)
+								{
+									pressArrow(spr, spr.ID, daNote);
+									/*
+									if (spr.animation.curAnim.name == 'confirm' && SONG.noteStyle != 'pixel')
+									{
+										spr.centerOffsets();
+										spr.offset.x -= 13;
+										spr.offset.y -= 13;
+									}
+									else
+										spr.centerOffsets();
+								*/
+								});
+							}
 						}
 					}
 					else
 					{
 						goodNoteHit(daNote);
-						boyfriend.holdTimer = daNote.sustainLength;
+						boyfriend.holdTimer = 0;
 						if (FlxG.save.data.cpuStrums)
 							{
 								playerStrums.forEach(function(spr:StaticArrow)


### PR DESCRIPTION
1. bf's hold timer is set to 0 rather than the sustain length of the note, so it plays the sing animations properly
2. i noticed there is no code for glowing the strums when playing a replay so i added it