### PR TITLE
building.md fix

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -36,13 +36,9 @@
 If you are planning to build for Windows, you also need to install **Visual Studio 2019**. While installing it, *don't click on any of the options to install workloads*. Instead, go to the **individual components** tab and choose the following:
 
 -   MSVC v142 - VS 2019 C++ x64/x86 build tools
--   MSVC v141 - VS 2017 C++ x64/x86 build tools
 -   Windows SDK (10.0.17763.0)
--   C++ Profiling tools
--   C++ CMake tools for windows
--   C++ ATL for v142 build tools (x86 & x64)
 
-This will install about 7 GB of crap, but is necessary to build for Windows.
+This will install about 4 GB of crap, but is necessary to build for Windows.
 
 ### macOS-only dependencies (these are required for building on macOS at all, including html5.)
 If you are running macOS, you'll need to install Xcode. You can download it from the macOS App Store or from the [Xcode website](https://developer.apple.com/xcode/).


### PR DESCRIPTION
Basically you only need

MSVC v142 - VS 2019 C++ x64/x86 build tools
Windows SDK (10.0.17763.0)
to compile to windows
