### PR TITLE
Add missing library to build instructions.

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -25,6 +25,7 @@
 	 - `haxelib install hscript`
 	 - `haxelib install newgrounds`
 	 - `haxelib git linc_luajit https://github.com/AndreiRudenko/linc_luajit.git`
+	 - `haxelib git hxvm-luajit https://github.com/KadeDev/hxvm-luajit`
 	 - `haxelib git faxe https://github.com/uhrobots/faxe`
 	 - `haxelib git polymod https://github.com/larsiusprime/polymod.git`
 	 - `haxelib git discord_rpc https://github.com/Aidan63/linc_discord-rpc`

--- a/docs/building.md
+++ b/docs/building.md
@@ -25,7 +25,7 @@
 	 - `haxelib install hscript`
 	 - `haxelib install newgrounds`
 	 - `haxelib git linc_luajit https://github.com/AndreiRudenko/linc_luajit.git`
-	 - `haxelib git hxvm-luajit https://github.com/KadeDev/hxvm-luajit`
+	 - `haxelib git hxvm-luajit https://github.com/nebulazorua/hxvm-luajit`
 	 - `haxelib git faxe https://github.com/uhrobots/faxe`
 	 - `haxelib git polymod https://github.com/larsiusprime/polymod.git`
 	 - `haxelib git discord_rpc https://github.com/Aidan63/linc_discord-rpc`


### PR DESCRIPTION
`hxvm-luajit` is necessary to build KadeEngine v1.7 but it's not included in the build documentation. This pull request adds it.