### PR TITLE
Add troubleshooting section to BUILDING.md.

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -61,3 +61,25 @@ Finally, we are ready to build.
 - The build will be in `Kade-Engine/export/release/<target>/bin`, with `<target>` being the target you built to in the previous step. (i.e. `Kade-Engine/export/release/windows/bin`)
 - Incase you added the -debug flag the files will be inside `Kade-Engine/export/debug/<target>/bin`
 - Only the `bin` folder is necessary to run the game. The other ones in `export/release/<target>` are not.
+
+## Troubleshooting
+If you are experiencing one of the common problems below, you can use the provided steps to fix the issue.
+
+### Type not found : StatePointer
+
+If you experience this problem, you may see lines like 
+
+```
+source/LuaClass.hx:33: characters 46-58 : Type not found : StatePointer
+```
+
+This problem occurs when running an old version of the libraries that power the Lua-based modcharting system. These libraries were replaced in Kade Engine v1.7.
+
+To fix this issue, run the following commands to reinstall the proper versions:
+
+```
+haxelib remove linc_luajit
+haxelib remove hxvm-luajit
+haxelib git linc_luajit https://github.com/nebulazorua/linc_luajit.git
+haxelib git hxvm-luajit https://github.com/nebulazorua/hxvm-luajit
+```


### PR DESCRIPTION
Commonly experienced issues with building of KadeEngine can be added to the documentation along with their solutions.

This troubleshooting guide resolves the issue seen in #1850 and #1905 for developers who previously built an older version of Kade Engine and are now attempting to build 1.7.
