### PR TITLE
Two new features for Animation Debugger.

### DIFF
--- a/source/AnimationDebug.hx
+++ b/source/AnimationDebug.hx
@@ -113,6 +113,9 @@ class AnimationDebug extends FlxState
 	{
 		textAnim.text = char.animation.curAnim.name;
 
+		if (FlxG.keys.justPressed.ENTER)
+			FlxG.switchState(new MainMenuState());
+
 		if (FlxG.keys.justPressed.E)
 			FlxG.camera.zoom += 0.25;
 		if (FlxG.keys.justPressed.Q)

--- a/source/AnimationDebug.hx
+++ b/source/AnimationDebug.hx
@@ -128,7 +128,7 @@ class AnimationDebug extends FlxState
 	{
 		textAnim.text = char.animation.curAnim.name;
 
-		if (FlxG.keys.justPressed.ENTER)
+		if (FlxG.keys.justPressed.ENTER || FlxG.keys.justPressed.ESCAPE)
 			FlxG.switchState(new MainMenuState());
 
 		if (FlxG.keys.justPressed.E)

--- a/source/AnimationDebug.hx
+++ b/source/AnimationDebug.hx
@@ -100,6 +100,21 @@ class AnimationDebug extends FlxState
 		}
 	}
 
+	function copyBoyOffsets():Void
+	{
+		var result = "";
+
+		for (anim => offsets in char.animOffsets)
+		{
+			var text = anim + " " + offsets.join(" ");
+			result += text + "\n";
+		}
+
+		trace("Outputting animation offsets to clipboard...");
+
+		openfl.system.System.setClipboard(result);
+	}
+
 	function updateTexts():Void
 	{
 		dumbTexts.forEach(function(text:FlxText)
@@ -195,6 +210,9 @@ class AnimationDebug extends FlxState
 			genBoyOffsets(false);
 			char.playAnim(animList[curAnim]);
 		}
+
+		if (FlxG.keys.justPressed.V)
+			copyBoyOffsets();
 
 		super.update(elapsed);
 	}


### PR DESCRIPTION
- Press `ENTER` or `ESCAPE` to return to the Main Menu.
  - Without this feature you have to close the application every time you open the Animation Debugger.
  - This redoes #1531 which appears to have been really broken when merging.
- Press `V` to copy all animation offsets to the clipboard.
  - `copyBoyOffsets` outputs all animation offsets in a format ready to paste into the offsets.txt file.