### PR TITLE
Fix a crash triggered by playing tutorial vocals in the Charter.

### DIFF
--- a/source/ChartingState.hx
+++ b/source/ChartingState.hx
@@ -1825,7 +1825,12 @@ class ChartingState extends MusicBeatState
 						lime.media.openal.AL.sourcef(FlxG.sound.music._channel.__source.__backend.handle, lime.media.openal.AL.PITCH, speed);
 						try
 						{
-							lime.media.openal.AL.sourcef(vocals._channel.__source.__backend.handle, lime.media.openal.AL.PITCH, speed);
+							// We need to make CERTAIN vocals exist and are non-empty
+							// before we try to play them. Otherwise the game crashes.  
+							if (vocals != null && vocals.length > 0)
+							{
+								lime.media.openal.AL.sourcef(vocals._channel.__source.__backend.handle, lime.media.openal.AL.PITCH, speed);
+							}
 						}
 						catch(e)
 						{


### PR DESCRIPTION
Steps to reproduce the bug this fixes:

1. Start the game and go to the Tutorial level (any difficulty).
2. Press 7 to open the Charting tool.
3. Press Space to initiate sound playback.
4. KadeEngine tries to play a null FlxSound, shits its pants, and dies.

Checking for `vocals != null` doesn't resolve it, but checking `vocals.length` does.