### PR TITLE
General polish

### DIFF
--- a/source/Note.hx
+++ b/source/Note.hx
@@ -224,6 +224,8 @@ class Note extends FlxSprite
 
 		if (isSustainNote && prevNote != null)
 		{
+			noteYOff = Math.round(-stepHeight + swagWidth * 0.5);
+			
 			noteScore * 0.2;
 			alpha = 0.6;
 
@@ -247,14 +249,11 @@ class Note extends FlxSprite
 				prevNote.animation.play(dataColor[prevNote.originColor] + 'hold');
 				prevNote.updateHitbox();
 
-
-				prevNote.scale.y *= (stepHeight + 1) / prevNote.height; // + 1 so that there's no odd gaps as the notes scroll
+				prevNote.scale.y *= stepHeight / prevNote.height;
 				prevNote.updateHitbox();
-				prevNote.noteYOff = Math.round(-prevNote.offset.y);
-
-				// prevNote.setGraphicSize();
-
-				noteYOff = Math.round(-offset.y);
+				
+				if (antialiasing)
+					prevNote.scale.y *= 1.0 + (1.0 / prevNote.frameHeight);
 			}
 		}
 	}
@@ -299,9 +298,8 @@ class Note extends FlxSprite
 		else
 		{
 			canBeHit = false;
-
-			if (strumTime <= Conductor.songPosition)
-				wasGoodHit = true;
+			//if (strumTime <= Conductor.songPosition)
+			//	wasGoodHit = true;
 		}
 
 		if (tooLate && !wasGoodHit)

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1134,9 +1134,12 @@ class PlayState extends MusicBeatState
 
 		startTimer = new FlxTimer().start(Conductor.crochet / 1000, function(tmr:FlxTimer)
 		{
-			dad.dance();
-			gf.dance();
-			boyfriend.playAnim('idle');
+			if (swagCounter != 4) //prevent animation overlap lol
+			{
+				dad.dance();
+				gf.dance();
+				boyfriend.playAnim('idle');
+			}
 
 			var introAssets:Map<String, Array<String>> = new Map<String, Array<String>>();
 			introAssets.set('default', ['ready', "set", "go"]);
@@ -2811,6 +2814,7 @@ class PlayState extends MusicBeatState
 		if (generatedMusic)
 		{
 			var holdArray:Array<Bool> = [controls.LEFT, controls.DOWN, controls.UP, controls.RIGHT];
+			var stepHeight = (0.45 * Conductor.stepCrochet * FlxMath.roundDecimal(PlayState.SONG.speed, 2));
 
 			notes.forEachAlive(function(daNote:Note)
 			{
@@ -2821,7 +2825,6 @@ class PlayState extends MusicBeatState
 				{
 					if (PlayStateChangeables.useDownscroll)
 					{
-						
 						if (daNote.mustPress)
 						{
 							daNote.y = (playerStrums.members[Math.floor(Math.abs(daNote.noteData))].y
@@ -2836,9 +2839,8 @@ class PlayState extends MusicBeatState
 									2))) - daNote.noteYOff;
 						if (daNote.isSustainNote)
 						{
-							// Remember = minus makes notes go up, plus makes them go down
-							//if (daNote.animation.curAnim.name.endsWith('end') && daNote.prevNote != null)
-							//	daNote.y += daNote.prevNote.height;
+							// Correct downscroll positioning
+							daNote.y -= daNote.height - stepHeight;
 
 							// If not in botplay, only clip sustain notes when properly hit, botplay gets to clip it everytime
 							if (!PlayStateChangeables.botPlay)

--- a/source/Ratings.hx
+++ b/source/Ratings.hx
@@ -92,14 +92,14 @@ class Ratings
         return ranking;
     }
     
-    public static var timingWindows = [166,135,90,45];
+    public static var timingWindows = [166.0,135.0,90.0,45.0];
 
-    public static function judgeNote(note:Note)
+    public static function judgeNote(noteDiff:Float)
     {
-        var diff = Math.abs(note.strumTime - Conductor.songPosition) / (PlayState.songMultiplier >= 1 ? PlayState.songMultiplier : 1);
+        var diff = Math.abs(noteDiff) / (PlayState.songMultiplier >= 1 ? PlayState.songMultiplier : 1);
         for(index in 0...timingWindows.length) // based on 4 timing windows, will break with anything else
         {
-            var time = timingWindows[index];
+            var time = timingWindows[index] * Conductor.timeScale;
             var nextTime = index + 1 > timingWindows.length - 1 ? 0 : timingWindows[index + 1];
             if (diff < time && diff >= nextTime)
             {


### PR DESCRIPTION
Polish and fix up various parts of the game.
- Fix sustain note rendering, for real this time! (a bit dodgy on downscroll it seems but it's good enough for now)
- Make CPU note hits happen immediately rather than 1 frame late, also fix countdown dances to not overlap with animation
- Fix judgements to use timeScale (idk about songMultiplier though im so sorry kade if this breaks shit later on LOL)
- Fix combo display so that it's not 1 behind and make it appear with a SHIT 0 COMBO when you miss and have a non-zero combo rather than showing you 0 combo when you hit a note after combo breaking (a la PSXFunkin and 0.2.9)