### PR TITLE
Improved Stage positioning debug menu

### DIFF
--- a/source/GameOverSubstate.hx
+++ b/source/GameOverSubstate.hx
@@ -73,6 +73,7 @@ class GameOverSubstate extends MusicBeatSubstate
 			else
 				FlxG.switchState(new FreeplayState());
 			PlayState.loadRep = false;
+			PlayState.stageTesting = false;
 		}
 
 		if (bf.animation.curAnim.name == 'firstDeath' && bf.animation.curAnim.curFrame == 12)

--- a/source/PauseSubState.hx
+++ b/source/PauseSubState.hx
@@ -224,6 +224,7 @@ class PauseSubState extends MusicBeatSubstate
 					}
 					PlayState.instance.clean();
 					FlxG.resetState();
+					PlayState.stageTesting = false;
 				case "Exit to menu":
 					PlayState.startTime = 0;
 					if (PlayState.instance.useVideo)
@@ -239,6 +240,7 @@ class PauseSubState extends MusicBeatSubstate
 						FlxG.save.data.downscroll = false;
 					}
 					PlayState.loadRep = false;
+					PlayState.stageTesting = false;
 					#if desktop
 					if (PlayState.luaModchart != null)
 					{

--- a/source/ResultsScreen.hx
+++ b/source/ResultsScreen.hx
@@ -197,6 +197,7 @@ class ResultsScreen extends FlxSubState
             music.fadeOut(0.3);
             
             PlayState.loadRep = false;
+            PlayState.stageTesting = false;
             PlayState.rep = null;
 
 			var songHighscore = StringTools.replace(PlayState.SONG.song, " ", "-");
@@ -226,6 +227,7 @@ class ResultsScreen extends FlxSubState
             PlayState.rep = null;
 
             PlayState.loadRep = false;
+            PlayState.stageTesting = false;
 
 			var songHighscore = StringTools.replace(PlayState.SONG.song, " ", "-");
 			switch (songHighscore) {

--- a/source/Stage.hx
+++ b/source/Stage.hx
@@ -16,7 +16,7 @@ class Stage
     public var tweenDuration:Float = 2; // How long will it tween hiding/showing BGs, variable above must be set to True for tween to activate
     public var toAdd:Array<Dynamic> = []; // Add BGs on stage startup, load BG in by using "toAdd.push(bgVar);"
     // Layering algorithm for noobs: Everything loads by the method of "On Top", example: You load wall first(Every other added BG layers on it), then you load road(comes on top of wall and doesn't clip through it), then loading street lights(comes on top of wall and road)
-    public var swagBacks:Map<String, Dynamic> = []; // Store BGs here to use them later in PlayState or when slowBacks activate
+    public var swagBacks:Map<String, Dynamic> = []; // Store BGs here to use them later in PlayState / with slowBacks / or to adjust position in stage position debug menu(press 8 while in PlayState)
     public var swagGroup:Map<String, FlxTypedGroup<Dynamic>> = []; //Store Groups
     public var animatedBacks:Array<FlxSprite> = []; // Store animated backgrounds and make them play animation(Animation must be named Idle!! Else use swagGroup)
     public var layInFront:Array<Array<FlxSprite>> = [[], [], []]; // BG layering, format: first [0] - in front of GF, second [1] - in front of opponent, third [2] - in front of boyfriend(and techincally also opponent since Haxe layering moment)
@@ -132,6 +132,7 @@ class Stage
 								var dancer:BackgroundDancer = new BackgroundDancer((370 * i) + 130, bgLimo.y - 400);
 								dancer.scrollFactor.set(0.4, 0.4);
 								grpLimoDancers.add(dancer);
+								swagBacks['dancer' + i] = dancer;
 							}
 
                             swagBacks['fastCar'] = fastCar;

--- a/source/StagePositioningDebug.hx
+++ b/source/StagePositioningDebug.hx
@@ -8,6 +8,11 @@ import flixel.text.FlxText;
 import flixel.FlxCamera;
 import flixel.FlxSprite;
 import flixel.util.FlxCollision;
+import openfl.events.Event;
+import openfl.events.IOErrorEvent;
+import openfl.net.FileReference;
+
+using StringTools;
 
 class StagePositioningDebug extends FlxState
 {
@@ -15,6 +20,8 @@ class StagePositioningDebug extends FlxState
 	public var daBf:String;
 	public var daGf:String;
 	public var opponent:String;
+
+	var _file:FileReference;
 
 	var gf:Character;
 	var boyfriend:Boyfriend;
@@ -161,7 +168,6 @@ class StagePositioningDebug extends FlxState
 			dragging = true;
 			updateMousePos();
 		}
-		FlxG.watch.addQuick('dragging', dragging);
 
 		if (dragging && FlxG.mouse.justMoved)
 		{
@@ -209,6 +215,9 @@ class StagePositioningDebug extends FlxState
 			}
 		}
 
+		if (FlxG.keys.pressed.CONTROL && FlxG.keys.justPressed.S)
+			saveBoyPos();
+
 		super.update(elapsed);
 	}
 
@@ -254,4 +263,74 @@ class StagePositioningDebug extends FlxState
 				curCharString = opponent;
 		}
 	}
+
+	function saveBoyPos():Void
+	{
+		var result = "";
+
+		for (spriteName => sprite in Stage.swagBacks)
+		{
+			var text = spriteName + " X: " + sprite.x + " Y: " + sprite.y;
+			result += text + "\n";
+		}
+		var curCharIndex:Int = 0;
+		var char:String = '';
+		for (sprite in curChars)
+		{
+			switch (curCharIndex)
+			{
+				case 0:
+					char = daGf;
+				case 1:
+					char = daBf;
+				case 2:
+					char = opponent;
+			}
+			result += char + ' X: ' + curChars[curCharIndex].x + " Y: " + curChars[curCharIndex].y + "\n";
+			++curCharIndex;
+		}
+
+		if ((result != null) && (result.length > 0))
+		{
+				_file = new FileReference();
+				_file.addEventListener(Event.COMPLETE, onSaveComplete);
+				_file.addEventListener(Event.CANCEL, onSaveCancel);
+				_file.addEventListener(IOErrorEvent.IO_ERROR, onSaveError);
+				_file.save(result.trim(), daStage + "Positions.txt");
+		}
+	}
+
+	/**
+	 * Called when the save file dialog is completed.
+	 */
+	 function onSaveComplete(_):Void
+		{
+			_file.removeEventListener(Event.COMPLETE, onSaveComplete);
+			_file.removeEventListener(Event.CANCEL, onSaveCancel);
+			_file.removeEventListener(IOErrorEvent.IO_ERROR, onSaveError);
+			_file = null;
+			FlxG.log.notice("Successfully saved OFFSET DATA.");
+		}
+
+	/**
+	 * Called when the save file dialog is cancelled.
+	 */
+	 function onSaveCancel(_):Void
+		{
+			_file.removeEventListener(Event.COMPLETE, onSaveComplete);
+			_file.removeEventListener(Event.CANCEL, onSaveCancel);
+			_file.removeEventListener(IOErrorEvent.IO_ERROR, onSaveError);
+			_file = null;
+		}
+
+	function onSaveError(_):Void
+		{
+			_file.removeEventListener(Event.COMPLETE, onSaveComplete);
+			_file.removeEventListener(Event.CANCEL, onSaveCancel);
+			_file.removeEventListener(IOErrorEvent.IO_ERROR, onSaveError);
+			_file = null;
+			FlxG.log.error("Problem saving Positions data");
+		}
+
+	
 }

--- a/source/StagePositioningDebug.hx
+++ b/source/StagePositioningDebug.hx
@@ -179,7 +179,15 @@ class StagePositioningDebug extends FlxState
 		if (dragging && FlxG.mouse.justReleased || FlxG.keys.justPressed.TAB)
 			dragging = false;
 
-		posText.text = (curCharString + " X: " + curChar.x + " Y: " + curChar.y);
+		if (FlxG.keys.pressed.Z)
+			curChar.angle -= 1 * Math.ceil(elapsed);
+		else if (FlxG.keys.pressed.X)
+			curChar.angle += 1 * Math.ceil(elapsed);
+		else if (FlxG.keys.pressed.R)
+			curChar.angle = 0;
+
+
+		posText.text = (curCharString + " X: " + curChar.x + " Y: " + curChar.y + " Rotation: " + curChar.angle);
 
 		if (FlxG.keys.justPressed.ESCAPE)
 		{
@@ -270,7 +278,7 @@ class StagePositioningDebug extends FlxState
 
 		for (spriteName => sprite in Stage.swagBacks)
 		{
-			var text = spriteName + " X: " + sprite.x + " Y: " + sprite.y;
+			var text = spriteName + " X: " + sprite.x + " Y: " + sprite.y + " Rotation: " + sprite.angle;
 			result += text + "\n";
 		}
 		var curCharIndex:Int = 0;
@@ -286,7 +294,7 @@ class StagePositioningDebug extends FlxState
 				case 2:
 					char = opponent;
 			}
-			result += char + ' X: ' + curChars[curCharIndex].x + " Y: " + curChars[curCharIndex].y + "\n";
+			result += char + ' X: ' + curChars[curCharIndex].x + " Y: " + curChars[curCharIndex].y + " Rotation: " + curChars[curCharIndex].angle + "\n";
 			++curCharIndex;
 		}
 

--- a/source/StagePositioningDebug.hx
+++ b/source/StagePositioningDebug.hx
@@ -309,7 +309,7 @@ class StagePositioningDebug extends FlxState
 			_file.removeEventListener(Event.CANCEL, onSaveCancel);
 			_file.removeEventListener(IOErrorEvent.IO_ERROR, onSaveError);
 			_file = null;
-			FlxG.log.notice("Successfully saved OFFSET DATA.");
+			FlxG.log.notice("Successfully saved Positions DATA.");
 		}
 
 	/**


### PR DESCRIPTION
1) Proper mouse hitbox registration on sprites
2) Ability to move BG objects themselves(Shift to switch from characters to BG and vice versa)
3) Save all of the positions to file(Ctrl + S)
4) Ability to preview changes in the game itself by pressing escape button

[**Video Showcase**](https://www.youtube.com/watch?v=WcnIeneIRbA)

5) [Ability to rotate sprites](https://www.youtube.com/watch?v=HXwlB77viDY) (Z/X when sprite is selected)

![image](https://user-images.githubusercontent.com/75626813/130689024-51e5388f-5c1e-4094-adf8-6f8201d72e15.png)

