### PR TITLE
Get rid of the bugged sustain notes in Downscroll

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2837,8 +2837,14 @@ class PlayState extends MusicBeatState
 						if (daNote.isSustainNote)
 						{
 							// Remember = minus makes notes go up, plus makes them go down
-							if (daNote.animation.curAnim.name.endsWith('end') && daNote.prevNote != null)
+							if (daNote.animation.curAnim.name.endsWith("end") && daNote.prevNote != null)
+							{
 								daNote.y += daNote.prevNote.height;
+							}
+							else
+							{
+								daNote.y += daNote.height / 2;
+							}
 
 							// If not in botplay, only clip sustain notes when properly hit, botplay gets to clip it everytime
 							if (!PlayStateChangeables.botPlay)


### PR DESCRIPTION
This simple PR fixes the end of sustain notes.
Fixes:
#1920 
#1930 

Before:
![image](https://user-images.githubusercontent.com/47796739/130823665-d592a788-1d78-45b2-aacc-d9db386b49bf.png)

After:
![image](https://user-images.githubusercontent.com/47796739/130824255-369d1a7a-95f9-406a-bc68-a428f6a76382.png)
