### PR TITLE
"FlxCamera.defaultCameras` is deprecated, use `FlxG.cameras.setDefaultDrawTarget` instead"

### DIFF
--- a/source/DiffOverview.hx
+++ b/source/DiffOverview.hx
@@ -62,7 +62,7 @@ class DiffOverview extends FlxSubState
 
         FlxG.cameras.add(camHUD);
 
-		FlxCamera.defaultCameras = [camGame];
+	FlxG.cameras.setDefaultDrawTarget(camGame, true);
 
         playerStrums = new FlxTypedGroup<FlxSprite>();
 

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -408,7 +408,7 @@ class PlayState extends MusicBeatState
 
 		camHUD.zoom = PlayStateChangeables.zoom;
 
-		FlxCamera.defaultCameras = [camGame];
+		FlxG.cameras.setDefaultDrawTarget(camGame, true);
 
 		persistentUpdate = true;
 		persistentDraw = true;


### PR DESCRIPTION
Since I'm guessing I'm not the only person who isn't a fan of seeing this warning EVERY SINGLE TIME they compile the engine, I decided to fix it. Both instances of FlxCamera.defaultCameras have been replaced with FlxG.cameras.setDefaultDrawTarget