### PR TITLE
Story Menu Antialiasing

### DIFF
--- a/source/MenuItem.hx
+++ b/source/MenuItem.hx
@@ -17,6 +17,7 @@ class MenuItem extends FlxSpriteGroup
 	{
 		super(x, y);
 		week = new FlxSprite().loadGraphic(Paths.image('storymenu/week' + weekNum));
+		week.antialiasing = FlxG.save.data.antialiasing;
 		add(week);
 	}
 

--- a/source/StoryMenuState.hx
+++ b/source/StoryMenuState.hx
@@ -179,6 +179,7 @@ class StoryMenuState extends MusicBeatState
 		leftArrow.animation.addByPrefix('idle', "arrow left");
 		leftArrow.animation.addByPrefix('press', "arrow push left");
 		leftArrow.animation.play('idle');
+		leftArrow.antialiasing = FlxG.save.data.antialiasing;
 		difficultySelectors.add(leftArrow);
 
 		sprDifficulty = new FlxSprite(leftArrow.x + 130, leftArrow.y);
@@ -187,6 +188,7 @@ class StoryMenuState extends MusicBeatState
 		sprDifficulty.animation.addByPrefix('normal', 'NORMAL');
 		sprDifficulty.animation.addByPrefix('hard', 'HARD');
 		sprDifficulty.animation.play('easy');
+		sprDifficulty.antialiasing = FlxG.save.data.antialiasing;
 		changeDifficulty();
 
 		difficultySelectors.add(sprDifficulty);
@@ -196,6 +198,7 @@ class StoryMenuState extends MusicBeatState
 		rightArrow.animation.addByPrefix('idle', 'arrow right');
 		rightArrow.animation.addByPrefix('press', "arrow push right", 24, false);
 		rightArrow.animation.play('idle');
+		rightArrow.antialiasing = FlxG.save.data.antialiasing;
 		difficultySelectors.add(rightArrow);
 
 		trace("Line 150");


### PR DESCRIPTION
The changes:
-Antialiasing for the week text (Tutorial, Week 1, etc.)
-Antialiasing for the difficulty selection sprites (Easy, Normal, Hard, and arrows)
-Enable or disable it using the Antialiasing setting.

tbh this should have been a pull request way before. the weird pixel blotchiness really annoyed me.

## Comparison

Enabled:
![image](https://user-images.githubusercontent.com/69328615/131777908-25f506ff-d642-4c77-851d-7c2b62ef3f78.png)

Disabled:
![image](https://user-images.githubusercontent.com/69328615/131777976-12050b5d-a21d-494b-b7fa-4b01a7aaf30f.png)
