### PR TITLE
Add note in the `lime rebuild extension-webm` section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-minimal

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-minimal

--- a/docs/building.md
+++ b/docs/building.md
@@ -32,9 +32,7 @@
 	 - `haxelib install actuate`
 	 - `haxelib git extension-webm https://github.com/KadeDev/extension-webm`
 	 - `lime rebuild extension-webm <ie. windows, macos, linux>`
-	      
-	      
-	      Note: for linux, you need to install the `g++-multilib` and `gcc-multilib` packages respectively. (use apt to install them.)
+	      - Note: for Linux, you need to install the `g++-multilib` and `gcc-multilib` packages respectively. (use apt to install them.)
 
 ### Windows-only dependencies (only for building *to* Windows. Building html5 on Windows does not require this)
 If you are planning to build for Windows, you also need to install **Visual Studio 2019**. While installing it, *don't click on any of the options to install workloads*. Instead, go to the **individual components** tab and choose the following:

--- a/docs/building.md
+++ b/docs/building.md
@@ -32,6 +32,8 @@
 	 - `haxelib install actuate`
 	 - `haxelib git extension-webm https://github.com/KadeDev/extension-webm`
 	 - `lime rebuild extension-webm <ie. windows, macos, linux>`
+	      
+	      
 	      Note: for linux, you need to install the `g++-multilib` and `gcc-multilib` packages respectively. (use apt to install them.)
 
 ### Windows-only dependencies (only for building *to* Windows. Building html5 on Windows does not require this)

--- a/docs/building.md
+++ b/docs/building.md
@@ -32,6 +32,7 @@
 	 - `haxelib install actuate`
 	 - `haxelib git extension-webm https://github.com/KadeDev/extension-webm`
 	 - `lime rebuild extension-webm <ie. windows, macos, linux>`
+	      Note: for linux, you need to install the `g++-multilib` and `gcc-multilib` packages respectively. (use apt to install them.)
 
 ### Windows-only dependencies (only for building *to* Windows. Building html5 on Windows does not require this)
 If you are planning to build for Windows, you also need to install **Visual Studio 2019**. While installing it, *don't click on any of the options to install workloads*. Instead, go to the **individual components** tab and choose the following:


### PR DESCRIPTION
Rebuilding extension-webm on linux fails if the `g++-multilib` and `gcc-multilib` packages aren't installed, this pr adds them as required dependencies 