### PR TITLE
Various Stage/Animation debug improvements

### DIFF
--- a/source/AnimationDebug.hx
+++ b/source/AnimationDebug.hx
@@ -81,6 +81,8 @@ class AnimationDebug extends FlxState
 
 		genBoyOffsets();
 
+    addHelpText();
+
 		camFollow = new FlxObject(0, 0, 2, 2);
 		camFollow.screenCenter();
 		add(camFollow);
@@ -172,6 +174,16 @@ class AnimationDebug extends FlxState
 		});
 	}
 
+  var helpText:FlxText;
+  function addHelpText():Void {
+    var helpTextValue = "Help:\nQ/E : Zoom in and out\nF : Flip\nI/J/K/L : Pan Camera\nW/S : Cycle Animation\nArrows : Offset Animation\nShift-Arrows : Offset Animation x10\nSpace : Replay Animation\nCTRL-S : Save Offsets to File\nEnter/ESC : Exit\nPress F1 to hide/show this!\n";
+    helpText = new FlxText(940, 20, 0, helpTextValue, 15);
+    helpText.scrollFactor.set();
+    helpText.color = FlxColor.BLUE;
+
+    add(helpText);
+  }
+
 	override function update(elapsed:Float)
 	{
 		textAnim.text = char.animation.curAnim.name;
@@ -261,6 +273,11 @@ class AnimationDebug extends FlxState
 
 		if (FlxG.keys.pressed.CONTROL && FlxG.keys.justPressed.S)
 			saveBoyOffsets();
+
+    if (FlxG.keys.justPressed.F1)
+			FlxG.save.data.showHelp = !FlxG.save.data.showHelp;
+
+    helpText.visible = FlxG.save.data.showHelp;
 
 		super.update(elapsed);
 	}

--- a/source/FreeplayState.hx
+++ b/source/FreeplayState.hx
@@ -328,7 +328,9 @@ class FreeplayState extends MusicBeatState
 		var upP = FlxG.keys.justPressed.UP;
 		var downP = FlxG.keys.justPressed.DOWN;
 		var accepted = FlxG.keys.justPressed.ENTER;
+    var dadDebug = FlxG.keys.justPressed.SIX;
 		var charting = FlxG.keys.justPressed.SEVEN;
+    var bfDebug = FlxG.keys.justPressed.ZERO;
 
 		var gamepad:FlxGamepad = FlxG.gamepads.lastActive;
 
@@ -420,7 +422,36 @@ class FreeplayState extends MusicBeatState
 			loadSong();
 		else if (charting)
 			loadSong(true);
+
+    // AnimationDebug and StageDebug are only enabled in debug builds.
+    #if debug
+    if (dadDebug) {
+      loadAnimDebug(true);
+    }
+    if (bfDebug) {
+      loadAnimDebug(false);
+    }
+    #end
 	}
+
+  function loadAnimDebug(dad:Bool = true) {
+    // First, get the song data.
+    var hmm;
+		try {
+			hmm = songData.get(songs[curSelected].songName)[curDifficulty];
+			if (hmm == null)
+				return;
+		} catch(ex) {
+			return;
+		}
+		PlayState.SONG = Song.conversionChecks(hmm);
+
+    var character = dad
+      ? PlayState.SONG.player2
+      : PlayState.SONG.player1;
+
+    LoadingState.loadAndSwitchState(new AnimationDebug(character));
+  }
 
 	function loadSong(isCharting:Bool = false)
 	{

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -958,8 +958,6 @@ class PlayState extends MusicBeatState
 			songPosBar.cameras = [camHUD];
 		}
 		kadeEngineWatermark.cameras = [camHUD];
-		if (loadRep)
-			replayTxt.cameras = [camHUD];
 
 		// if (SONG.song == 'South')
 		// FlxG.camera.alpha = 0.7;

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -919,6 +919,7 @@ class PlayState extends MusicBeatState
 		replayTxt.borderSize = 4;
 		replayTxt.borderQuality = 2;
 		replayTxt.scrollFactor.set();
+    replayTxt.cameras = [camHUD];
 		if (loadRep)
 		{
 			add(replayTxt);
@@ -930,6 +931,7 @@ class PlayState extends MusicBeatState
 		botPlayState.scrollFactor.set();
 		botPlayState.borderSize = 4;
 		botPlayState.borderQuality = 2;
+    botPlayState.cameras = [camHUD];
 		if (PlayStateChangeables.botPlay && !loadRep)
 			add(botPlayState);
 

--- a/source/StageDebugState.hx
+++ b/source/StageDebugState.hx
@@ -1,5 +1,6 @@
 package;
 
+import flixel.util.FlxColor;
 import flixel.FlxState;
 import flixel.FlxG;
 import flixel.FlxObject;
@@ -109,7 +110,20 @@ class StageDebugState extends FlxState
 		posText.scrollFactor.set();
 		posText.cameras = [camHUD];
 		add(posText);
+
+    addHelpText();
 	}
+
+  var helpText:FlxText;
+  function addHelpText():Void {
+    var helpTextValue = "Help:\nQ/E : Zoom in and out\nI/J/K/L : Pan Camera\nSpace : Cycle Object\nShift : Switch Mode (Char/Stage)\nClick and Drag : Move Active Object\nZ/X : Rotate Object\nR : Reset Rotation\nCTRL-S : Save Offsets to File\nESC : Return to Stage\nPress F1 to hide/show this!\n";
+    helpText = new FlxText(940, 0, 0, helpTextValue, 15);
+    helpText.scrollFactor.set();
+		helpText.cameras = [camHUD];
+    helpText.color = FlxColor.WHITE;
+
+    add(helpText);
+  }
 
 	override public function update(elapsed:Float)
 	{
@@ -227,6 +241,11 @@ class StageDebugState extends FlxState
 
 		if (FlxG.keys.pressed.CONTROL && FlxG.keys.justPressed.S)
 			saveBoyPos();
+
+    if (FlxG.keys.justPressed.F1)
+			FlxG.save.data.showHelp = !FlxG.save.data.showHelp;
+
+    helpText.visible = FlxG.save.data.showHelp;
 
 		super.update(elapsed);
 	}


### PR DESCRIPTION
* Add togglable help text to Stage Debug view (similar to the new Help text from the Charter).
* Add togglable help text to Animation Debug view (similar to the new Help text from the Charter).
* Add hotkey: press 6 in Freeplay menu to view Animation Debug for that song's dad character.
* Add hotkey: press 0 in Freeplay menu to view Animation Debug for that song's boyfriend character.
* Bug fix: Tie BOTPLAY and REPLAY text to HUD camera. Resolves #2232. Was too lazy to make a separate PR just for this.