### PR TITLE
Github Actions are now run on pull requests.

### DIFF
--- a/.github/workflows/html5.yml
+++ b/.github/workflows/html5.yml
@@ -3,7 +3,7 @@
 name: HTML5 Build CI
 
 # Controls when the workflow will run
-on: push
+on: [push, pull_request]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,7 +3,7 @@
 name: Linux Build CI
 
 # Controls when the workflow will run
-on: push
+on: [push, pull_request]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@
 name: Windows Build CI
 
 # Controls when the workflow will run
-on: push
+on: [push, pull_request]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
Once this is merged, pull requests will have a ✔️ or ❌ next to them based on whether they can be built by GitHub.

If they can't, the pull request needs to be fixed such that it builds properly. I highly recommend setting this option to enforce this:

![image](https://user-images.githubusercontent.com/4635334/133003707-5e9b94e6-2f82-4d78-ad4f-5e241c1cb749.png)
