### PR TITLE
Skip to the proper part of the song when you press Enter during the Title intro.

### DIFF
--- a/source/TitleState.hx
+++ b/source/TitleState.hx
@@ -357,8 +357,6 @@ class TitleState extends MusicBeatState
 		else
 			gfDance.animation.play('danceLeft');
 
-		FlxG.log.add(curBeat);
-
 		switch (curBeat)
 		{
 			case 0:
@@ -443,6 +441,10 @@ class TitleState extends MusicBeatState
 					if (logoBl.angle == 4) 
 						FlxTween.angle(logoBl, logoBl.angle, -4, 4, {ease: FlxEase.quartInOut});
 				}, 0);
+
+      // It always bugged me that it didn't do this before.
+      // Skip ahead in the song to the drop.
+      FlxG.sound.music.time = 9400; // 9.4 seconds
 
 			skippedIntro = true;
 		}


### PR DESCRIPTION
If you press Enter during the intro, it now sets the current time in the song to 9.4 seconds in, about the time when the intro would normally stop.

I always thought the soundtrack sounded really weird when the intro part of the song was still playing as GF was dancing. This fixes that.

plz kaed merg this i beg you