### PR TITLE
Fix camera in GameplayCustomizeState, add previewing combo

### DIFF
--- a/source/GameplayCustomizeState.hx
+++ b/source/GameplayCustomizeState.hx
@@ -37,7 +37,6 @@ class GameplayCustomizeState extends MusicBeatState
 	var playerStrums:FlxTypedGroup<FlxSprite>;
 	private var camHUD:FlxCamera;
 	private var camGame:FlxCamera;
-	private var camNotes:FlxCamera;
 
 	public override function create()
 	{

--- a/source/GameplayCustomizeState.hx
+++ b/source/GameplayCustomizeState.hx
@@ -28,7 +28,7 @@ class GameplayCustomizeState extends MusicBeatState
 	var text:FlxText;
 	var blackBorder:FlxSprite;
 
-	var bf:Boyfriend;
+	var boyfriend:Boyfriend;
 	var dad:Character;
 	var gf:Character;
 
@@ -36,6 +36,8 @@ class GameplayCustomizeState extends MusicBeatState
 	var strumLineNotes:FlxTypedGroup<FlxSprite>;
 	var playerStrums:FlxTypedGroup<FlxSprite>;
 	private var camHUD:FlxCamera;
+	private var camGame:FlxCamera;
+	private var camNotes:FlxCamera;
 
 	public override function create()
 	{
@@ -44,26 +46,27 @@ class GameplayCustomizeState extends MusicBeatState
 		DiscordClient.changePresence("Customizing Gameplay Modules", null);
 		#end
 
-		sick = new FlxSprite().loadGraphic(Paths.loadImage('sick', 'shared'));
-		sick.antialiasing = FlxG.save.data.antialiasing;
-		sick.scrollFactor.set();
-		background = new FlxSprite(-1000, -200).loadGraphic(Paths.loadImage('stageback', 'shared'));
-		curt = new FlxSprite(-500, -300).loadGraphic(Paths.loadImage('stagecurtains', 'shared'));
+		background = new FlxSprite(-600, -200).loadGraphic(Paths.loadImage('stageback', 'shared'));
 		front = new FlxSprite(-650, 600).loadGraphic(Paths.loadImage('stagefront', 'shared'));
+		curt = new FlxSprite(-500, -300).loadGraphic(Paths.loadImage('stagecurtains', 'shared'));
 		background.antialiasing = FlxG.save.data.antialiasing;
-		curt.antialiasing = FlxG.save.data.antialiasing;
 		front.antialiasing = FlxG.save.data.antialiasing;
-
-		// Conductor.changeBPM(102);
-		persistentUpdate = true;
+		curt.antialiasing = FlxG.save.data.antialiasing;
 
 		super.create();
 
+		camGame = new FlxCamera();
 		camHUD = new FlxCamera();
 		camHUD.bgColor.alpha = 0;
+
+		FlxG.cameras.reset(camGame);
 		FlxG.cameras.add(camHUD);
 
+		FlxCamera.defaultCameras = [camGame];
+
 		camHUD.zoom = FlxG.save.data.zoom;
+
+		persistentUpdate = persistentDraw = true;
 
 		background.scrollFactor.set(0.9, 0.9);
 		curt.scrollFactor.set(0.9, 0.9);
@@ -77,7 +80,7 @@ class GameplayCustomizeState extends MusicBeatState
 
 		dad = new Character(100, 100, 'dad');
 
-		bf = new Boyfriend(770, 450, 'bf');
+		boyfriend = new Boyfriend(770, 450, 'bf');
 
 		gf = new Character(400, 130, 'gf');
 		gf.scrollFactor.set(0.95, 0.95);
@@ -87,15 +90,12 @@ class GameplayCustomizeState extends MusicBeatState
 		camFollow.setPosition(camPos.x, camPos.y);
 
 		add(gf);
-		add(bf);
+		add(boyfriend);
 		add(dad);
-
-		add(sick);
 
 		add(camFollow);
 
 		FlxG.camera.follow(camFollow, LOCKON, 0.01);
-		// FlxG.camera.setScrollBounds(0, FlxG.width, 0, FlxG.height);
 		FlxG.camera.zoom = 0.9;
 		FlxG.camera.focusOn(camFollow.getPosition());
 
@@ -113,29 +113,36 @@ class GameplayCustomizeState extends MusicBeatState
 
 		playerStrums = new FlxTypedGroup<FlxSprite>();
 
-		sick.cameras = [camHUD];
+		sick = new FlxSprite().loadGraphic(Paths.loadImage('sick', 'shared'));
+		sick.setGraphicSize(Std.int(sick.width * 0.7));
+		sick.antialiasing = FlxG.save.data.antialiasing;
+		sick.scrollFactor.set();
+		sick.updateHitbox();
+		add(sick);
+
 		strumLine.cameras = [camHUD];
-		playerStrums.cameras = [camHUD];
+		strumLineNotes.cameras = [camHUD];
+		sick.cameras = [camHUD];
 
 		generateStaticArrows(0);
 		generateStaticArrows(1);
 
 		text = new FlxText(5, FlxG.height + 40, 0,
-			"Click and drag around gameplay elements to customize their positions. Press R to reset. Q/E to change zoom. Press Escape to go back.", 12);
+			"Click and drag around gameplay elements to customize their positions. Press R to reset. Q/E to change zoom. C to show combo. Escape to exit.",
+			12);
 		text.scrollFactor.set();
 		text.setFormat("VCR OSD Mono", 16, FlxColor.WHITE, LEFT, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
 
 		blackBorder = new FlxSprite(-30, FlxG.height + 40).makeGraphic((Std.int(text.width + 900)), Std.int(text.height + 600), FlxColor.BLACK);
 		blackBorder.alpha = 0.5;
 
-		background.cameras = [camHUD];
+		blackBorder.cameras = [camHUD];
 		text.cameras = [camHUD];
 
 		text.scrollFactor.set();
 		background.scrollFactor.set();
 
 		add(blackBorder);
-
 		add(text);
 
 		FlxTween.tween(text, {y: FlxG.height - 18}, 2, {ease: FlxEase.elasticInOut});
@@ -199,6 +206,78 @@ class GameplayCustomizeState extends MusicBeatState
 			FlxG.save.data.changedHit = true;
 		}
 
+		if (FlxG.keys.justPressed.C)
+		{
+			var visibleCombos:Array<FlxSprite> = [];
+
+			var seperatedScore:Array<Int> = [];
+
+			var comboSplit:Array<String> = (FlxG.random.int(0, 420) + "").split('');
+
+			// make sure we have 3 digits to display (looks weird otherwise lol)
+			if (comboSplit.length == 1)
+			{
+				seperatedScore.push(0);
+				seperatedScore.push(0);
+			}
+			else if (comboSplit.length == 2)
+				seperatedScore.push(0);
+
+			for (i in 0...comboSplit.length)
+			{
+				var str:String = comboSplit[i];
+				seperatedScore.push(Std.parseInt(str));
+			}
+
+			var daLoop:Int = 0;
+			for (i in seperatedScore)
+			{
+				var numScore:FlxSprite = new FlxSprite().loadGraphic(Paths.loadImage('num' + Std.int(i)));
+				numScore.screenCenter();
+				numScore.x = sick.x + (43 * daLoop) - 50;
+				numScore.y = sick.y + 100;
+				numScore.cameras = [camHUD];
+				numScore.antialiasing = FlxG.save.data.antialiasing;
+				numScore.setGraphicSize(Std.int(numScore.width * 0.5));
+				numScore.updateHitbox();
+
+				numScore.acceleration.y = FlxG.random.int(200, 300);
+				numScore.velocity.y -= FlxG.random.int(140, 160);
+				numScore.velocity.x = FlxG.random.float(-5, 5);
+
+				add(numScore);
+
+				visibleCombos.push(numScore);
+
+				FlxTween.tween(numScore, {alpha: 0}, 0.2, {
+					onComplete: function(tween:FlxTween)
+					{
+						visibleCombos.remove(numScore);
+						numScore.destroy();
+					},
+					onUpdate: function(tween:FlxTween)
+					{
+						if (!visibleCombos.contains(numScore))
+						{
+							tween.cancel();
+							numScore.destroy();
+						}
+					},
+					startDelay: Conductor.crochet * 0.002
+				});
+
+				if (visibleCombos.length > seperatedScore.length + 20)
+				{
+					for (i in 0...seperatedScore.length - 1)
+					{
+						visibleCombos.remove(visibleCombos[visibleCombos.length - 1]);
+					}
+				}
+
+				daLoop++;
+			}
+		}
+
 		if (FlxG.keys.justPressed.R)
 		{
 			sick.x = defaultX;
@@ -224,15 +303,19 @@ class GameplayCustomizeState extends MusicBeatState
 
 		if (curBeat % 2 == 0)
 		{
-			bf.dance();
+			boyfriend.dance();
 			dad.dance();
 		}
 		else if (dad.curCharacter == 'spooky' || dad.curCharacter == 'gf')
 			dad.dance();
 
 		gf.dance();
-		FlxG.camera.zoom += 0.015;
-		camHUD.zoom += 0.010;
+
+		if (!FlxG.keys.pressed.SPACE)
+		{
+			FlxG.camera.zoom += 0.015;
+			camHUD.zoom += 0.010;
+		}
 
 		trace('beat');
 	}


### PR DESCRIPTION
Make changes to GameplayCustomizeState, fixing the zoomed in camera alongside other inconsistencies such as the rating going underneath notes instead of on top. It now more accurately represents what you are going to see in gameplay.

This adds a new feature to preview the combo with C, which will help out with the placement of the rating.

https://user-images.githubusercontent.com/15317421/135388022-2279b7eb-41ca-4dec-b2fb-44bb834d9a50.mp4

An additional hotkey on Space has been made to temporarily stop the camera zooming in every beat, which also helps with rating placement. This isn't mentioned in the bottom ticker due to not having any space (hueh) on screen for it.

These changes should help out towards a better implementation of PR #1951.
