### PR TITLE
fix html5 button not being detected in firefox 92.0

### DIFF
--- a/source/Debug.hx
+++ b/source/Debug.hx
@@ -182,11 +182,14 @@ class Debug
 		{
 			var paramArray:Array<Dynamic> = [data];
 
-			if (info.customParams != null)
+			if (info != null)
 			{
-				for (i in info.customParams)
+				if (info.customParams != null)
 				{
-					paramArray.push(i);
+					for (i in info.customParams)
+					{
+						paramArray.push(i);
+					}
 				}
 			}
 

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -996,6 +996,8 @@ class PlayState extends MusicBeatState
 		if (!loadRep)
 			rep = new Replay("na");
 
+		// This allow arrow key to be detected by flixel. See https://github.com/HaxeFlixel/flixel/issues/2190
+		FlxG.keys.preventDefaultKeys = [];
 		FlxG.stage.addEventListener(KeyboardEvent.KEY_DOWN, handleInput);
 		FlxG.stage.addEventListener(KeyboardEvent.KEY_UP, releaseInput);
 		super.create();


### PR DESCRIPTION
Hello. Had a fun mod made a few month ago. Wanted to play on linux, so ported it to latest master (cause it didn't compiled for linux otherwise). Then wanted to compile it for web browser. Didn't worked. So decided to fix this, (and using the occation to contribe to a Libre software).

Fix this issue : https://github.com/KadeDev/Kade-Engine/issues/1277

This patch may have the side effect (not tested) to not disable scrolling. As I only tested with ``lime build html5``, it had the JS canvas/whatever take the full page, so there is no canvas.