### PR TITLE
Lane underlay, judgement counter & fixes

### DIFF
--- a/source/KadeEngineData.hx
+++ b/source/KadeEngineData.hx
@@ -121,6 +121,15 @@ class KadeEngineData
 		if (FlxG.save.data.zoom == null)
 			FlxG.save.data.zoom = 1;
 
+		if (FlxG.save.data.judgementCounter == null)
+			FlxG.save.data.judgementCounter = true;
+
+		if (FlxG.save.data.laneUnderlay == null)
+			FlxG.save.data.laneUnderlay = false;
+
+		if (FlxG.save.data.laneTransparency == null)
+			FlxG.save.data.laneTransparency = 0;
+
 		var gamepad:FlxGamepad = FlxG.gamepads.lastActive;
 
 		KeyBinds.gamepad = gamepad != null;

--- a/source/Options.hx
+++ b/source/Options.hx
@@ -880,6 +880,79 @@ class CamZoomOption extends Option
 	}
 }
 
+class JudgementCounter extends Option
+{
+	public function new(desc:String)
+	{
+		super();
+		description = desc;
+	}
+
+	public override function press():Bool
+	{
+		FlxG.save.data.judgementCounter = !FlxG.save.data.judgementCounter;
+		display = updateDisplay();
+		return true;
+	}
+
+	private override function updateDisplay():String
+	{
+		return (FlxG.save.data.judgementCounter ? "Show Judgement Counter" : "No Judgement Counter");
+	}
+}
+
+class LaneUnderlayOption extends Option
+{
+	public function new(desc:String)
+	{
+		super();
+		description = desc;
+		acceptValues = true;
+	}
+
+	public override function press():Bool
+	{
+		FlxG.save.data.laneUnderlay = !FlxG.save.data.laneUnderlay;
+		display = updateDisplay();
+		return true;
+	}
+
+	private override function updateDisplay():String
+	{
+		return (FlxG.save.data.laneUnderlay ? "Lane underlay" : "No lane underlay");
+	}
+
+	override function right():Bool
+	{
+		FlxG.save.data.laneTransparency += 0.1;
+
+		if (FlxG.save.data.laneTransparency < 0)
+			FlxG.save.data.laneTransparency = 0;
+
+		if (FlxG.save.data.laneTransparency > 1)
+			FlxG.save.data.laneTransparency = 1;
+		return true;
+	}
+
+	override function getValue():String
+	{
+		return "Current Lane Underlay transparency: " + HelperFunctions.truncateFloat(FlxG.save.data.laneTransparency, 1);
+	}
+
+	override function left():Bool
+	{
+		FlxG.save.data.laneTransparency -= 0.1;
+
+		if (FlxG.save.data.laneTransparency < 0)
+			FlxG.save.data.laneTransparency = 0;
+
+		if (FlxG.save.data.laneTransparency > 1)
+			FlxG.save.data.laneTransparency = 1;
+
+		return true;
+	}
+}
+
 class LockWeeksOption extends Option
 {
 	var confirm:Bool = false;

--- a/source/OptionsMenu.hx
+++ b/source/OptionsMenu.hx
@@ -44,6 +44,7 @@ class OptionsMenu extends MusicBeatState
 			new CamZoomOption("Toggle the camera zoom in-game."),
 			new StepManiaOption("Sets the colors of the arrows depending on quantization instead of direction."),
 			new AccuracyOption("Display accuracy information on the info bar."),
+			new JudgementCounter("Shows your current judgements on the left side of the screen."), new LaneUnderlayOption("Toggles lane underlay"),
 			new SongPositionOption("Show the song's current position as a scrolling bar."),
 			new Colour("The color behind icons now fit with their theme. (e.g. Pico = green)"),
 			new NPSDisplayOption("Shows your current Notes Per Second on the info bar."),


### PR DESCRIPTION
- Added lane underlay as a toggleable option (transparency can be changed with left/right)
- Added Judgement Counter as a toggleable option.
- Centered the notes (Was clearly noticeable due to the lane underlay)
- Centered the score text (It has annoyed me for a while so I did it while I was at it)