### PR TITLE
Add lane underway and middle scroll to customize state

### DIFF
--- a/source/OptionsMenu.hx
+++ b/source/OptionsMenu.hx
@@ -39,8 +39,7 @@ class OptionsMenu extends MusicBeatState
 			new CustomizeGameplay("Drag and drop gameplay modules to your prefered positions!")
 		]),
 		new OptionCategory("Appearance", [
-			new NoteskinOption("Change your current noteskin"),
-			new EditorRes("Not showing the editor grid will greatly increase editor performance"),
+			new NoteskinOption("Change your current noteskin"), new EditorRes("Not showing the editor grid will greatly increase editor performance"),
 			new DistractionsAndEffectsOption("Toggle stage distractions that can hinder your gameplay."),
 			new CamZoomOption("Toggle the camera zoom in-game."),
 			new StepManiaOption("Sets the colors of the arrows depending on quantization instead of direction."),
@@ -60,8 +59,8 @@ class OptionsMenu extends MusicBeatState
 			new MissSoundsOption("Toggle miss sounds playing when you don't hit a note."), new ScoreScreen("Show the score screen after the end of a song"),
 			new ShowInput("Display every single input on the score screen."),
 			new Optimization("No characters or backgrounds. Just a usual rhythm game layout."), new BotPlay("Showcase your charts and mods with autoplay."),
-			#if debug new DebugMode("Go to the animation debug menu.")]),
-			#end
+			#if debug new DebugMode("Go to the animation debug menu."), #end
+		]),
 		new OptionCategory("Saves and Data", [
 			#if desktop // new ReplayOption("View saved song replays."),
 			#end


### PR DESCRIPTION
This PR adds the lane underway and middle scroll options to the Gameplay Customization state.
![2021-10-10_00-54-34_Kade_Engine](https://user-images.githubusercontent.com/15317421/136687438-3d34c232-b677-4fcc-bec8-7dcf81d9bf6e.png)
![2021-10-10_01-36-11_Kade_Engine](https://user-images.githubusercontent.com/15317421/136688683-d9149fdc-5cc4-4b42-b099-f62d836afbfc.png)