### PR TITLE
Fix school crashing gameplay customize state

### DIFF
--- a/source/GameOverSubstate.hx
+++ b/source/GameOverSubstate.hx
@@ -69,7 +69,16 @@ class GameOverSubstate extends MusicBeatSubstate
 			FlxG.sound.music.stop();
 
 			if (PlayState.isStoryMode)
+			{
+				GameplayCustomizeState.freeplayBf = 'bf';
+				GameplayCustomizeState.freeplayDad = 'dad';
+				GameplayCustomizeState.freeplayGf = 'gf';
+				GameplayCustomizeState.freeplayNoteStyle = 'normal';
+				GameplayCustomizeState.freeplayStage = 'stage';
+				GameplayCustomizeState.freeplaySong = 'bopeebo';
+				GameplayCustomizeState.freeplayWeek = 1;
 				FlxG.switchState(new StoryMenuState());
+			}
 			else
 				FlxG.switchState(new FreeplayState());
 			PlayState.loadRep = false;

--- a/source/GameplayCustomizeState.hx
+++ b/source/GameplayCustomizeState.hx
@@ -57,7 +57,7 @@ class GameplayCustomizeState extends MusicBeatState
 	public static var freeplayGf:String = 'gf';
 	public static var freeplayNoteStyle:String = 'normal';
 	public static var freeplayStage:String = 'stage';
-	public static var freeplaySong:String = 'Bopeebo';
+	public static var freeplaySong:String = 'bopeebo';
 	public static var freeplayWeek:Int = 1;
 
 	public override function create()

--- a/source/PauseSubState.hx
+++ b/source/PauseSubState.hx
@@ -227,7 +227,16 @@ class PauseSubState extends MusicBeatSubstate
 					PlayState.instance.clean();
 
 					if (PlayState.isStoryMode)
+					{
+						GameplayCustomizeState.freeplayBf = 'bf';
+						GameplayCustomizeState.freeplayDad = 'dad';
+						GameplayCustomizeState.freeplayGf = 'gf';
+						GameplayCustomizeState.freeplayNoteStyle = 'normal';
+						GameplayCustomizeState.freeplayStage = 'stage';
+						GameplayCustomizeState.freeplaySong = 'bopeebo';
+						GameplayCustomizeState.freeplayWeek = 1;
 						FlxG.switchState(new StoryMenuState());
+					}
 					else
 						FlxG.switchState(new FreeplayState());
 			}

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -302,6 +302,15 @@ class PlayState extends MusicBeatState
 		FlxG.mouse.visible = false;
 		instance = this;
 
+		// grab variables here too or else its gonna break stuff later on
+		GameplayCustomizeState.freeplayBf = SONG.player1;
+		GameplayCustomizeState.freeplayDad = SONG.player2;
+		GameplayCustomizeState.freeplayGf = SONG.gfVersion;
+		GameplayCustomizeState.freeplayNoteStyle = SONG.noteStyle;
+		GameplayCustomizeState.freeplayStage = SONG.stage;
+		GameplayCustomizeState.freeplaySong = SONG.songId;
+		GameplayCustomizeState.freeplayWeek = storyWeek;
+
 		previousRate = songMultiplier - 0.05;
 
 		if (previousRate < 1.00)
@@ -3382,6 +3391,13 @@ class PlayState extends MusicBeatState
 					}
 					else
 					{
+						GameplayCustomizeState.freeplayBf = 'bf';
+						GameplayCustomizeState.freeplayDad = 'dad';
+						GameplayCustomizeState.freeplayGf = 'gf';
+						GameplayCustomizeState.freeplayNoteStyle = 'normal';
+						GameplayCustomizeState.freeplayStage = 'stage';
+						GameplayCustomizeState.freeplaySong = 'bopeebo';
+						GameplayCustomizeState.freeplayWeek = 1;
 						FlxG.sound.playMusic(Paths.music('freakyMenu'));
 						Conductor.changeBPM(102);
 						FlxG.switchState(new StoryMenuState());

--- a/source/Stage.hx
+++ b/source/Stage.hx
@@ -341,7 +341,8 @@ class Stage extends MusicBeatState
 					var bgGirls = new BackgroundGirls(-100, 190);
 					bgGirls.scrollFactor.set(0.9, 0.9);
 
-					if (PlayState.SONG.songId.toLowerCase() == 'roses')
+					// if (PlayState.SONG.songId.toLowerCase() == 'roses')
+					if (GameplayCustomizeState.freeplaySong == 'roses')
 					{
 						if (FlxG.save.data.distractions)
 							bgGirls.getScared();


### PR DESCRIPTION
Fixes one of the issues introduced from PR #2517, where the game crashes in Gameplay Customize State when you pick either Senpai or Roses in Freeplay without playing a song in PlayState first.

GameplayCustomizeState will also get reset back to default when you leave Story Mode.

This can probably be done in a better fashion, but it works at the moment.

https://user-images.githubusercontent.com/15317421/138571932-cfa64d64-a9af-48cf-bbf6-78c71ecadc17.mp4

