### PR TITLE
Avoid logTrace calls in production.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -14,6 +14,8 @@ Windows (`x86`), Windows (`x86_64`), Linux, or macOS? Specify below.
 
 ## What version of the game are you using? Look in the bottom left corner of the main menu.
 
-## Have you identified any steps to reproduce the bug? If so, please describe them below. Use images if possible.
-
 ## Please describe your issue. Provide extensive detail and images if possible.
+
+## Please check the `logs` folder within your game directory, and upload the most recent game logs if you can.
+
+## Have you identified any steps to reproduce the bug? If so, please describe them below. Use images if possible.

--- a/source/Debug.hx
+++ b/source/Debug.hx
@@ -80,11 +80,12 @@ class Debug
 	 */
 	public static function logTrace(input:Dynamic, ?pos:haxe.PosInfos):Void
 	{
+		#if debug
 		if (input == null)
 			return;
 		var output = formatOutput(input, pos);
-		writeToFlxGLog(output, LOG_STYLE_TRACE);
 		writeToLogFile(output, 'TRACE');
+		#end
 	}
 
 	/**


### PR DESCRIPTION
These are computationally expensive since they involve a file system write and happen frequently, like whenever you press a note.

Also edited the Bug Report issue template to require users to upload the log file. I implemented them for a reason.