### PR TITLE
Update documentation to use new Polymod HaxeLib

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -20,6 +20,7 @@
 	 - `haxelib install flixel-ui`
 	 - `haxelib install hscript`
 	 - `haxelib install flixel-addons`
+	 - `haxelib install polymod`
 	 - `haxelib install actuate`
 	 - `haxelib run lime setup`
 	 - `haxelib run lime setup flixel`
@@ -27,7 +28,6 @@
 	 - `haxelib git linc_luajit https://github.com/nebulazorua/linc_luajit.git`
 	 - `haxelib git hxvm-luajit https://github.com/nebulazorua/hxvm-luajit`
 	 - `haxelib git faxe https://github.com/uhrobots/faxe`
-	 - `haxelib git polymod https://github.com/MasterEric/polymod.git`
 	 - `haxelib git discord_rpc https://github.com/Aidan63/linc_discord-rpc`
 	 - `haxelib git extension-webm https://github.com/KadeDev/extension-webm`
 	 - `lime rebuild extension-webm <ie. windows, macos, linux>`


### PR DESCRIPTION
This is now the official distribution channel of Polymod as of two minutes ago:

https://lib.haxe.org/p/polymod/