### PR TITLE
Songs ending properly at any rate.

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2089,18 +2089,12 @@ class PlayState extends MusicBeatState
 		{
 			if (songStarted && !endingSong)
 			{
-				// Song ends abruptly on slow rate even with second condition being deleted,
-				// and if it's deleted on songs like cocoa then it would end without finishing instrumental fully,
-				// so no reason to delete it at all
-				if (unspawnNotes.length == 0 && notes.length == 0 && FlxG.sound.music.time / songMultiplier > (songLength - 100))
+				// We are actually men and fixed this shit B)
+				if ((FlxG.sound.music.length / songMultiplier) - Conductor.songPosition <= 0)
 				{
 					Debug.logTrace("we're fuckin ending the song ");
-
 					endingSong = true;
-					new FlxTimer().start(2, function(timer)
-					{
-						endSong();
-					});
+					endSong();
 				}
 			}
 		}


### PR DESCRIPTION
Fixed the early song Ending (Songs used to end when notes stop appearing)
Now songs end normally at any rate (when the instrumental ends basically). 

Found issues: #2580 not fixed in 1.8.1

https://user-images.githubusercontent.com/88955176/154230197-d27c6271-6eff-406f-94c4-003aefb16696.mp4


