### PR TITLE
Fixing pause glitch.

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1877,11 +1877,14 @@ class PlayState extends MusicBeatState
 			if (FlxG.sound.music.playing)
 			{
 				FlxG.sound.music.pause();
-				if (vocals != null)
-					if (vocals.playing)
-						vocals.pause();
 			}
-
+			if (vocals != null)
+			{
+				if (vocals.playing)
+				{
+					vocals.pause();
+				};
+			}
 			#if FEATURE_DISCORD
 			DiscordClient.changePresence("PAUSED on "
 				+ SONG.song


### PR DESCRIPTION
I was making my own mod and noticed a glitch that caused the vocals to keep playing while the game is paused. I got a little annoyed with it and tried making a fix. After around two hours of clicking and typing aimlessly, I found a stupidly simple solution that worked for me. Afterwards, I decided to post it here so that others can have this glitch patched too. The change I've made is on lines 1877 to 1887.  At first, it looks like it would accomplish literally nothing, but it worked great for me. Just test it out or something.